### PR TITLE
refactor: localize product footer state logic

### DIFF
--- a/public/js/design/components/product-card-footer.js
+++ b/public/js/design/components/product-card-footer.js
@@ -1,19 +1,20 @@
 /*
  * ProductCardFooter Vue 组件
- * 作用：在产品卡底部展示 MOQ（按设计/按颜色）、价格（基础价/定制价）、预计交付/到达日期以及数量增减控件，
- *      并与 Pinia 全局状态（useCanvasStore、usePrintMethodStore）保持实时联动。
+ * 作用：在产品卡底部展示 MOQ、价格、预计交付/到达日期及数量控件，并管理与这些展示直接相关的本地状态。
+ * 迁移：将原 Pinia store 中仅供 #product-card-footer 使用的数量、样品订单与日期计算逻辑迁移至组件内部，
+ *      以便就地维护并减少对全局 store 的耦合。
  * 依赖：
- *   - window.Vue：从全局 Vue 运行时中解构出 createApp/computed/watch 等 API；
+ *   - window.Vue：从全局 Vue 运行时中解构出 createApp/reactive/computed/watch/onMounted/onBeforeUnmount 等 API；
  *   - Pinia stores：从 ../stores/index.js 引入 pinia、useCanvasStore、usePrintMethodStore。
  * 挂载点：#product-card-footer（在 template-canvas-display.php 中为 .product-card 添加了该 id）。
  * 设计约定：
- *   - 组件只负责展示与交互（数量增减），不直接控制样品订单开关，仅消费 Pinia 的派生数据；
+ *   - 组件只负责展示与交互（数量增减），不直接控制样品订单开关，仅消费 Pinia 与 DOM 的派生数据；
  *   - 模板字符串内部不写 HTML 注释，以避免在 DOM 中产生额外注释节点；
- *   - 保持纯函数式计算（computed）与最小副作用（watch 中对数量的矫正）。
+ *   - 保持纯函数式计算（computed）与最小副作用（watch 中对数量的矫正、与 DOM 的同步监听）。
  */
 
-// 从全局 Vue 运行时解构出需要的 API；ref 当前未用到，保留以备后续拓展
-const { createApp, ref, computed, watch } = window.Vue;
+// 从全局 Vue 运行时解构出需要的 API
+const { createApp, reactive, computed, watch, onMounted, onBeforeUnmount } = window.Vue;
 // 引入 Pinia 实例和两个业务 Store（画布与印刷方法）
 import { pinia, useCanvasStore, usePrintMethodStore } from '../stores/index.js';
 
@@ -25,14 +26,281 @@ export const ProductCardFooter = {
     const canvasStore = useCanvasStore(); // 画布/产品视图相关业务状态
     const printStore = usePrintMethodStore(); // 印刷方法/成本相关业务状态
 
+    // === 状态 (state) ===
+    const state = reactive({
+      /** 当前下单数量：驱动数量输入框与加减按钮的展示与步长计算，默认值与历史逻辑保持一致为 100。 */
+      quantity: 100,
+      /** 样品订单勾选状态：用于判断数量控件是否禁用以及数量步长是否按批次计算，由页面复选框同步更新。 */
+      isSampleOrder: false,
+      /** 预计到货日期：保存计算结果供模板展示，也方便后续扩展其他组件读取。 */
+      estimatedArrivalDate: '2025-01-15'
+    });
+
+    // === Actions ===
+    /**
+     * 更新数量值。
+     * @param {number} newValue - 新的目标数量，可能来自输入框或按钮计算。
+     * 逻辑：确保结果为整数且不小于 1，与原 store 中 Math.max(1, newValue) 的行为保持一致。
+     */
+    const setQuantity = (newValue) => {
+      const numeric = parseInt(newValue, 10);
+      state.quantity = Number.isFinite(numeric) ? Math.max(1, numeric) : 1;
+    };
+
+    /**
+     * 设置样品订单状态。
+     * @param {boolean} value - 是否勾选样品订单复选框。
+     * 逻辑：将任意真值转换为布尔值，便于后续计算 MOQ 与数量禁用逻辑。
+     */
+    const setIsSampleOrder = (value) => {
+      state.isSampleOrder = Boolean(value);
+    };
+
+    /**
+     * 写回预计到货日期。
+     * @param {string} arrivalDate - 最新计算的到货日期字符串，可为空字符串表示无法计算。
+     * 逻辑：统一通过该方法更新状态，方便未来在此增加埋点或联动逻辑。
+     */
+    const updateEstimatedArrivalDate = (arrivalDate) => {
+      state.estimatedArrivalDate = arrivalDate || '';
+    };
+
+    // 与页面 DOM 的样品订单复选框同步
+    let removeSampleCheckboxListener = null;
+    const handleSampleCheckboxChange = (event) => {
+      setIsSampleOrder(event?.target?.checked);
+    };
+
+    onMounted(() => {
+      const sampleCheckbox = document.querySelector('.sample-check input#sample');
+      if (sampleCheckbox) {
+        setIsSampleOrder(sampleCheckbox.checked);
+        sampleCheckbox.addEventListener('change', handleSampleCheckboxChange);
+        removeSampleCheckboxListener = () => {
+          sampleCheckbox.removeEventListener('change', handleSampleCheckboxChange);
+        };
+      }
+    });
+
+    onBeforeUnmount(() => {
+      if (typeof removeSampleCheckboxListener === 'function') {
+        removeSampleCheckboxListener();
+      }
+    });
+
+    // === Getters ===
+    /** 获取当前数量，供其他计算属性复用。 */
+    const getQuantity = computed(() => state.quantity);
+
+    /** 获取样品订单状态，用于控制数量步长及禁用逻辑。 */
+    const getIsSampleOrder = computed(() => state.isSampleOrder);
+
+    /** 判断数量控件是否需要禁用：样品订单场景下禁用手动调整数量。 */
+    const isQuantityControlDisabled = computed(() => state.isSampleOrder);
+
+    /**
+     * 计算颜色选择带来的最大 MOQ。
+     * 逻辑：遍历 selectedColorsByView，兼容 _custom.value 结构与多种布尔表示。
+     */
+    const maxUsedColorMoqQuantity = computed(() => {
+      let max = 0;
+      const colorsMap = canvasStore?.selectedColorsByView || {};
+      for (const viewId in colorsMap) {
+        if (!Object.prototype.hasOwnProperty.call(colorsMap, viewId)) continue;
+        const colorData = colorsMap[viewId];
+        if (!colorData || !colorData.moq_setting) continue;
+        let moqSetting = colorData.moq_setting;
+        if (moqSetting && moqSetting._custom && moqSetting._custom.value) {
+          moqSetting = moqSetting._custom.value;
+        }
+        const moqEnabled = moqSetting && (moqSetting.enable === true || moqSetting.enable === 1 || moqSetting.enable === '1' || moqSetting.enable === 'true');
+        if (!moqEnabled) continue;
+        const qty = Number(moqSetting.minimum_order_quantity);
+        if (Number.isFinite(qty) && qty > max) {
+          max = qty;
+        }
+      }
+      return max;
+    });
+
+    /**
+     * 计算颜色选择中的最高基础单价。
+     * 逻辑：遍历所有已选颜色，取 price 字段的最大值，默认返回 0。
+     */
+    const maxPriceFromSelectedColors = computed(() => {
+      let maxPrice = 0;
+      const colorsMap = canvasStore?.selectedColorsByView || {};
+      for (const viewId in colorsMap) {
+        if (!Object.prototype.hasOwnProperty.call(colorsMap, viewId)) continue;
+        const colorData = colorsMap[viewId];
+        if (!colorData) continue;
+        const price = Number(colorData.price);
+        if (Number.isFinite(price) && price > maxPrice) {
+          maxPrice = price;
+        }
+      }
+      return maxPrice;
+    });
+
+    /**
+     * 统计所有已使用印刷方式中的最大工艺耗时（process_time）。
+     * 逻辑：遍历 printStore.usedPrintMethodsByView，取数值最大值，默认返回 0。
+     */
+    const maxProcessTimeFromPrintMethods = computed(() => {
+      if (!printStore || !printStore.usedPrintMethodsByView) return 0;
+      let maxProcessTime = 0;
+      const usedPrintMethodsByView = printStore.usedPrintMethodsByView || {};
+      for (const viewId in usedPrintMethodsByView) {
+        if (!Object.prototype.hasOwnProperty.call(usedPrintMethodsByView, viewId)) continue;
+        const methodsMap = usedPrintMethodsByView[viewId] || {};
+        for (const methodId in methodsMap) {
+          if (!Object.prototype.hasOwnProperty.call(methodsMap, methodId)) continue;
+          const method = methodsMap[methodId];
+          if (method && method.apiData && method.apiData.process_time) {
+            const processTime = Number(method.apiData.process_time);
+            if (Number.isFinite(processTime) && processTime > maxProcessTime) {
+              maxProcessTime = processTime;
+            }
+          }
+        }
+      }
+      return maxProcessTime;
+    });
+
+    /**
+     * 计算颜色与印刷方式综合后的最终 MOQ。
+     * 逻辑：分别计算颜色 MOQ 与印刷方式 MOQ 的最大值，二者取最大并确保最小返回值为 1。
+     */
+    const calculatedMoq = computed(() => {
+      let maxColorMoq = 0;
+      let maxPrintMethodMoq = 0;
+
+      const colorsMap = canvasStore?.selectedColorsByView || {};
+      for (const viewId in colorsMap) {
+        if (!Object.prototype.hasOwnProperty.call(colorsMap, viewId)) continue;
+        const colorData = colorsMap[viewId];
+        if (!colorData || !colorData.moq_setting) continue;
+        let moqSetting = colorData.moq_setting;
+        if (moqSetting && moqSetting._custom && moqSetting._custom.value) {
+          moqSetting = moqSetting._custom.value;
+        }
+        const moqEnabled = moqSetting && (moqSetting.enable === true || moqSetting.enable === 1 || moqSetting.enable === '1' || moqSetting.enable === 'true');
+        if (!moqEnabled) continue;
+        const qty = Number(moqSetting.minimum_order_quantity);
+        if (Number.isFinite(qty) && qty > maxColorMoq) {
+          maxColorMoq = qty;
+        }
+      }
+
+      if (printStore && printStore.usedPrintMethodsByView) {
+        const usedPrintMethodsByView = printStore.usedPrintMethodsByView || {};
+        for (const viewId in usedPrintMethodsByView) {
+          if (!Object.prototype.hasOwnProperty.call(usedPrintMethodsByView, viewId)) continue;
+          const methodsMap = usedPrintMethodsByView[viewId] || {};
+          for (const methodId in methodsMap) {
+            if (!Object.prototype.hasOwnProperty.call(methodsMap, methodId)) continue;
+            const method = methodsMap[methodId];
+            if (!method || !method.apiData) continue;
+            const api = method.apiData;
+            const moqEnabled = api.moq_enabled === true || api.moq_enabled === 1 || api.moq_enabled === '1' || api.moq_enabled === 'true';
+            if (!moqEnabled) continue;
+            const qty = Number(api.moq_quantity);
+            if (Number.isFinite(qty) && qty > maxPrintMethodMoq) {
+              maxPrintMethodMoq = qty;
+            }
+          }
+        }
+      }
+
+      const finalMoq = Math.max(maxColorMoq, maxPrintMethodMoq);
+      return finalMoq > 0 ? finalMoq : 1;
+    });
+
+    /**
+     * 获取批量销售的步长数量。
+     * 逻辑：优先读取 sell_in_batch_info.batch_quantity，其次读取旧字段 batch_quantity，若未启用批量销售则返回 1。
+     */
+    const batchQuantity = computed(() => {
+      const productData = canvasStore?.productData;
+      if (!productData || !productData.product || !productData.product.data) {
+        return 1;
+      }
+      const product = productData.product.data;
+      if (product.sell_in_batch === true) {
+        if (product.sell_in_batch_info && product.sell_in_batch_info.batch_quantity) {
+          const batchQty = Number(product.sell_in_batch_info.batch_quantity);
+          return Number.isFinite(batchQty) && batchQty > 0 ? batchQty : 1;
+        }
+        if (product.batch_quantity) {
+          const batchQty = Number(product.batch_quantity);
+          return Number.isFinite(batchQty) && batchQty > 0 ? batchQty : 1;
+        }
+      }
+      return 1;
+    });
+
+    /**
+     * 计算预计发货日期：以颜色 RTS 最大值与印刷方式最大处理时间求和。
+     */
+    const estimatedDeliveryDateGetter = computed(() => {
+      const currentDate = new Date();
+      const maxRtsValue = Number(canvasStore?.getTotalMaxRtsForBulkOrder || 0);
+      const maxProcessTime = Number(maxProcessTimeFromPrintMethods.value || 0);
+      const totalProcessingDays = maxRtsValue + maxProcessTime;
+      const daysToAdd = totalProcessingDays > 0 ? totalProcessingDays : 0;
+      const deliveryDate = new Date(currentDate);
+      deliveryDate.setDate(currentDate.getDate() + daysToAdd);
+      const year = deliveryDate.getFullYear();
+      const month = String(deliveryDate.getMonth() + 1).padStart(2, '0');
+      const day = String(deliveryDate.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    });
+
+    /**
+     * 计算预计到货日期：在发货日期基础上叠加 shipping_info 对应的 RTS 时间，并更新状态。
+     */
+    const estimatedArrivalDateGetter = computed(() => {
+      const deliveryDateStr = estimatedDeliveryDateGetter.value;
+      if (!deliveryDateStr) return '';
+      const deliveryDate = new Date(deliveryDateStr);
+      if (Number.isNaN(deliveryDate.getTime())) return '';
+
+      const productData = canvasStore?.productData;
+      let shippingDays = 5;
+      const isSampleOrderChecked = getIsSampleOrder.value;
+
+      if (productData && productData.product && productData.product.data && productData.product.data.shipping_info) {
+        const shippingInfo = productData.product.data.shipping_info;
+        if (isSampleOrderChecked && shippingInfo.rts_for_sample_order) {
+          shippingDays = Number(shippingInfo.rts_for_sample_order) || 0;
+        } else if (!isSampleOrderChecked && shippingInfo.rts_for_bulk_order) {
+          shippingDays = Number(shippingInfo.rts_for_bulk_order) || 0;
+        }
+      }
+
+      if (shippingDays === 0) {
+        shippingDays = isSampleOrderChecked ? 1 : 2;
+      }
+
+      const arrivalDate = new Date(deliveryDate);
+      arrivalDate.setDate(deliveryDate.getDate() + shippingDays);
+      const year = arrivalDate.getFullYear();
+      const month = String(arrivalDate.getMonth() + 1).padStart(2, '0');
+      const day = String(arrivalDate.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    });
+
+    // 同步预计到货日期到状态，保持与原 store 中的可读属性一致
+    watch(estimatedArrivalDateGetter, (val) => {
+      updateEstimatedArrivalDate(val);
+    }, { immediate: true });
+
     // 是否在 API 配置中启用样品订单（样品订单通常 MOQ 为 1）
     const isSampleOrderEnabledByApi = computed(() => {
       try {
         const val = canvasStore?.productData?.customization_settings?.data?.moq_sample_order;
-        // 兼容后端返回的多种布尔表达形式
         return val === true || val === 1 || val === '1' || val === 'true';
       } catch (e) {
-        // 若读取失败，视为未启用样品订单
         return false;
       }
     });
@@ -42,13 +310,10 @@ export const ProductCardFooter = {
 
     // 是否展示「按颜色」的 MOQ；优先读取 Pinia 的派生标识，若不存在则回退到产品配置
     const showColor = computed(() => {
-      // 兼容历史：某些场景下 store 中可能不存在 shouldShowMoqColor 字段
       if (Object.prototype.hasOwnProperty.call(canvasStore, 'shouldShowMoqColor')) {
         return !!canvasStore.shouldShowMoqColor;
       } else {
-        // 回退：直接读取产品的 customization_settings 配置项
         const raw = canvasStore?.productData?.customization_settings?.data?.moq_items_color;
-        // 将各种“关闭”状态统一识别为不展示
         return !(raw === false || raw === 0 || raw === 'false' || raw === '0' || raw === null || raw === undefined);
       }
     });
@@ -57,84 +322,73 @@ export const ProductCardFooter = {
     const moqDesignQty = computed(() => {
       if (isSampleOrderEnabledByApi.value) return 1;
       const maxQty = Number(printStore ? printStore.getMaxUsedMoqQuantity : 0);
-      return Number.isFinite(maxQty) ? maxQty : 0; // 兜底为 0，避免 NaN
+      return Number.isFinite(maxQty) ? maxQty : 0;
     });
 
     // 「按颜色」的 MOQ 数量：样品订单时固定为 1；否则取颜色选择中实际使用的最大 MOQ
     const moqColorQty = computed(() => {
       if (isSampleOrderEnabledByApi.value) return 1;
-      const maxQty = Number(canvasStore ? canvasStore.getMaxUsedColorMoqQuantity : 0);
-      return Number.isFinite(maxQty) ? maxQty : 0; // 兜底为 0，避免 NaN
+      const maxQty = Number(maxUsedColorMoqQuantity.value || 0);
+      return Number.isFinite(maxQty) ? maxQty : 0;
     });
 
     // MOQ 展示文案：保持与原有页面文案一致（单位 Pcs）
     const moqDesignText = computed(() => `${moqDesignQty.value}Pcs / Design`);
     const moqColorText = computed(() => `${moqColorQty.value}Pcs / Color`);
 
-    // 价格展示（基础价/定制价）：
-    // - 基础价来自颜色选择的最大单价（按视图与颜色选中状态计算）
+    // 价格展示（基础价/定制价）
     const basePrice = computed(() => {
-      const maxPrice = canvasStore.getMaxPriceFromSelectedColors || 0;
-      return Number.isFinite(maxPrice) ? maxPrice.toFixed(1) : '0.0'; // 统一 1 位小数显示
+      const maxPrice = maxPriceFromSelectedColors.value || 0;
+      return Number.isFinite(maxPrice) ? maxPrice.toFixed(1) : '0.0';
     });
-    // - 定制价来自印刷方法的总成本（按已使用的方法聚合）
     const customizationPrice = computed(() => {
       const total = printStore.getTotalPrintCostFromUsedMethods || 0;
-      return Number.isFinite(total) ? total.toFixed(2) : '0.00'; // 统一 2 位小数显示
+      return Number.isFinite(total) ? total.toFixed(2) : '0.00';
     });
 
-    // 预计交付/到达日期：直接映射 Pinia 的派生字段，保持与原逻辑一致
-    const estimatedDeliveryDate = computed(() => canvasStore.estimatedDeliveryDate);
-    const estimatedArrivalDate = computed(() => canvasStore.estimatedArrivalDate);
+    // 预计交付/到达日期
+    const estimatedDeliveryDate = computed(() => estimatedDeliveryDateGetter.value);
+    const estimatedArrivalDate = computed(() => estimatedArrivalDateGetter.value);
 
-    // 数量控件的可用状态：由业务规则决定（如某些组合不允许手动修改数量）
-    const quantityDisabled = computed(() => canvasStore.isQuantityControlDisabled);
+    // 数量控件的可用状态
+    const quantityDisabled = computed(() => isQuantityControlDisabled.value);
 
-    // 与 Pinia 的数量做双向绑定：
-    // - 读取：使用 store 的 getter；
-    // - 写入：进行整数解析与校验，合法后再调用 setQuantity。
+    // 与数量的双向绑定
     const quantity = computed({
-      get: () => canvasStore.getQuantity,
+      get: () => getQuantity.value,
       set: (val) => {
         const num = parseInt(val, 10);
-        if (Number.isFinite(num)) canvasStore.setQuantity(num);
+        if (Number.isFinite(num)) setQuantity(num);
       },
     });
 
-    // 最小数量：
-    // - 非样品订单时，优先使用 Pinia 计算好的 MOQ（getCalculatedMoq）；
-    // - 若无法计算（或结果不合法），则兜底为 1。
+    // 最小数量：非样品订单时使用计算得到的 MOQ，兜底为 1
     const minQuantity = computed(() => {
-      const calculatedMoq = canvasStore.getCalculatedMoq;
-      return Number.isFinite(calculatedMoq) && calculatedMoq > 0 ? calculatedMoq : 1;
+      const calculatedMoqValue = Number(calculatedMoq.value || 0);
+      return Number.isFinite(calculatedMoqValue) && calculatedMoqValue > 0 ? calculatedMoqValue : 1;
     });
 
-    // 监听最小值与当前数量：当数量小于最小值时进行矫正，确保业务规则生效
+    // 监听最小值与当前数量：当数量小于最小值时进行矫正
     watch([minQuantity, quantity], ([minQ, q]) => {
       if (q < minQ && minQ > 0) {
-        canvasStore.setQuantity(minQ);
+        setQuantity(minQ);
       }
-    }, { immediate: true }); // immediate：初始化时也执行一次，避免初始状态不合法
+    }, { immediate: true });
 
     // 点击「-」按钮：按步长递减
-    // - 样品订单：步长为 1；
-    // - 普通订单：步长为批量数量（getBatchQuantity），至少为 1；
-    // - 并且不允许小于最小数量。
     const onMinus = () => {
-      if (quantityDisabled.value) return; // 若禁用则直接返回
-      const isSampleOrder = canvasStore.getIsSampleOrder;
-      const step = isSampleOrder ? 1 : (canvasStore.getBatchQuantity || 1);
+      if (quantityDisabled.value) return;
+      const step = getIsSampleOrder.value ? 1 : (batchQuantity.value || 1);
       const newVal = Math.max(minQuantity.value, (quantity.value || 1) - step);
-      canvasStore.setQuantity(newVal);
+      setQuantity(newVal);
     };
 
-    // 点击「+」按钮：按步长递增（同上），不做上限限制，由业务侧控制
+    // 点击「+」按钮：按步长递增
     const onPlus = () => {
-      if (quantityDisabled.value) return; // 若禁用则直接返回
-      const isSampleOrder = canvasStore.getIsSampleOrder;
-      const step = isSampleOrder ? 1 : (canvasStore.getBatchQuantity || 1);
+      if (quantityDisabled.value) return;
+      const step = getIsSampleOrder.value ? 1 : (batchQuantity.value || 1);
       const newVal = (quantity.value || 1) + step;
-      canvasStore.setQuantity(newVal);
+      setQuantity(newVal);
     };
 
     // 暴露到模板使用的响应式数据与事件处理函数
@@ -149,8 +403,7 @@ export const ProductCardFooter = {
   // 模板说明：
   // - 左侧信息块（product-card__info）：展示 MOQ、价格以及两个预计日期；
   // - 右侧数量块（product-card__quantity）：提供「-」「+」按钮与 number 输入框；
-  //   输入框使用 v-model.number 与 Pinia 的数量同步，readonly 受 quantityDisabled 控制。
-  template: `    
+  template: `
       <div class="product-card__info">
         <div class="product-card__detail">
           <span class="product-card__label">Minimum Order Quantity</span>
@@ -180,16 +433,16 @@ export const ProductCardFooter = {
         <input type="number" :min="minQuantity" v-model.number="quantity" class="product-card__input" :readonly="quantityDisabled">
         <button class="product-card__button product-card__button--plus" :disabled="quantityDisabled" @click="onPlus">+</button>
       </div>
-  
+
   `
 };
 
 // 组件挂载的自执行函数：在页面就绪后立即尝试挂载到指定容器
 (function mountProductCardFooter(){
   const container = document.getElementById('product-card-footer');
-  if (!container) return; // 若页面未提供挂载点则安全退出
+  if (!container) return;
   const app = createApp(ProductCardFooter);
-  app.use(pinia); // 注入 Pinia，使组件内能够访问 useCanvasStore/usePrintMethodStore
-  app.mount('#product-card-footer'); // 将组件挂载至容器
-  window.ProductCardFooter = ProductCardFooter; // 暴露到全局，便于在控制台调试
+  app.use(pinia);
+  app.mount('#product-card-footer');
+  window.ProductCardFooter = ProductCardFooter;
 })();

--- a/public/js/design/stores/index.js
+++ b/public/js/design/stores/index.js
@@ -10,15 +10,6 @@ const { createPinia, defineStore } = window.Pinia;
 export const useCanvasStore = defineStore('canvas', {
     // 3. state 定义所有需要全局管理的数据
     state: () => ({
-        // 预期到货日期
-        estimatedArrivalDate: '2025-01-15',
-
-        // 数量
-        quantity: 100,
-
-        // Sample Order 状态
-        isSampleOrder: false,
-
         // canvasStates：存储每个画板的状态（如对象、图层等），初始有3个画板
         canvasStates: { canvas1: null, canvas2: null, canvas3: null },
         // activeCanvasId：当前激活的画板 id，默认是 canvas1
@@ -51,15 +42,6 @@ export const useCanvasStore = defineStore('canvas', {
     }),
     // 4. getters 定义依赖状态的计算逻辑（所有依赖 Store 状态的计算放在这里）
     getters: {
-        // 获取当前数量
-        getQuantity: (state) => state.quantity,
-
-        // 获取Sample Order状态
-        getIsSampleOrder: (state) => state.isSampleOrder,
-
-        // 判断数量控件是否应该被禁用（Sample Order时禁用）
-        isQuantityControlDisabled: (state) => state.isSampleOrder,
-
         // 原始开关值
         moqItemsDesignRaw: (state) => state.productData && state.productData.customization_settings && state.productData.customization_settings.data
             ? state.productData.customization_settings.data.moq_items_design
@@ -120,44 +102,6 @@ export const useCanvasStore = defineStore('canvas', {
             return state.selectedColorsByView[vid] || null;
         },
         
-        // 获取"所有视图中"且 moq_setting.enable 为真时，对应 moq_setting.minimum_order_quantity 的最大值
-        // 若无符合条件的记录，则返回 0
-        getMaxUsedColorMoqQuantity: (state) => {
-            let max = 0;
-            const colorsMap = state.selectedColorsByView || {};
-            for (const viewId in colorsMap) {
-                if (!Object.prototype.hasOwnProperty.call(colorsMap, viewId)) continue;
-                const colorData = colorsMap[viewId];
-                if (!colorData || !colorData.moq_setting) continue;
-                const moqSetting = colorData.moq_setting;
-                // 兼容多种布尔表示: true/1/'1'/'true'
-                const moqEnabled = moqSetting.enable === true || moqSetting.enable === 1 || moqSetting.enable === '1' || moqSetting.enable === 'true';
-                if (!moqEnabled) continue;
-                const qty = Number(moqSetting.minimum_order_quantity);
-                if (Number.isFinite(qty) && qty > max) {
-                    max = qty;
-                }
-            }
-            return max;
-        },
-        
-        // ===== 新增：获取所有视图中price的最大值 =====
-        // 从selectedColorsByView获取所有视图的price最大值
-        getMaxPriceFromSelectedColors: (state) => {
-            let maxPrice = 0;
-            const colorsMap = state.selectedColorsByView || {};
-            for (const viewId in colorsMap) {
-                if (!Object.prototype.hasOwnProperty.call(colorsMap, viewId)) continue;
-                const colorData = colorsMap[viewId];
-                if (!colorData) continue;
-                const price = Number(colorData.price);
-                if (Number.isFinite(price) && price > maxPrice) {
-                    maxPrice = price;
-                }
-            }
-            return maxPrice;
-        },
-        
         // ===== 新增：计算各视图 rts_for_bulk_order 最大值相加 =====
         // 获取所有视图中 rts_for_bulk_order 的最大值相加
         getTotalMaxRtsForBulkOrder: (state) => {
@@ -173,35 +117,6 @@ export const useCanvasStore = defineStore('canvas', {
                 }
             }
             return total;
-        },
-        
-        // ===== 新增：计算预期发货日期 =====
-        // 基于今天的日期加上颜色选择后的最大 RTS 值和印刷方式的最大 process_time
-        estimatedDeliveryDate() {
-            const currentDate = new Date();
-            
-            // 获取颜色选择后的最大 RTS 值（这里使用 bulk order 的值作为默认）
-            const maxRtsValue = this.getTotalMaxRtsForBulkOrder;
-            
-            // 获取印刷方式的最大 process_time
-            const maxProcessTime = this.getMaxProcessTimeFromPrintMethods;
-            
-            // 计算总的处理时间：RTS 值 + 印刷方式处理时间
-            const totalProcessingDays = maxRtsValue + maxProcessTime;
-            
-            // 如果总处理时间为 0，使用默认的 0天
-            const daysToAdd = totalProcessingDays > 0 ? totalProcessingDays : 0;
-            
-            // 计算目标日期
-            const deliveryDate = new Date(currentDate);
-            deliveryDate.setDate(currentDate.getDate() + daysToAdd);
-            
-            // 格式化日期为 YYYY-MM-DD 格式
-            const year = deliveryDate.getFullYear();
-            const month = String(deliveryDate.getMonth() + 1).padStart(2, '0');
-            const day = String(deliveryDate.getDate()).padStart(2, '0');
-            
-            return `${year}-${month}-${day}`;
         },
         
         // ===== 新增：计算各视图 rts_for_sample_order 最大值相加 =====
@@ -221,200 +136,9 @@ export const useCanvasStore = defineStore('canvas', {
             return total;
         },
         
-        // ===== 新增：计算各视图印刷方式的最大 process_time =====
-        // 获取所有视图中印刷方式的最大 process_time
-        getMaxProcessTimeFromPrintMethods: (state) => {
-            const printMethodStore = window.usePrintMethodStore && window.usePrintMethodStore();
-            if (!printMethodStore) return 0;
-            
-            let maxProcessTime = 0;
-            const usedPrintMethodsByView = printMethodStore.usedPrintMethodsByView || {};
-            
-            for (const viewId in usedPrintMethodsByView) {
-                if (!Object.prototype.hasOwnProperty.call(usedPrintMethodsByView, viewId)) continue;
-                const methodsMap = usedPrintMethodsByView[viewId] || {};
-                
-                for (const methodId in methodsMap) {
-                    if (!Object.prototype.hasOwnProperty.call(methodsMap, methodId)) continue;
-                    const method = methodsMap[methodId];
-                    
-                    if (method && method.apiData && method.apiData.process_time) {
-                        const processTime = Number(method.apiData.process_time);
-                        if (Number.isFinite(processTime) && processTime > maxProcessTime) {
-                            maxProcessTime = processTime;
-                        }
-                    }
-                }
-            }
-            
-            return maxProcessTime;
-        },
-        
-        // ===== 新增：计算预期到货日期 =====
-        // 基于 estimatedDeliveryDate 加上产品的 shipping_info 中的 RTS 值
-        estimatedArrivalDate() {
-            // 获取预期发货日期
-            const deliveryDateStr = this.estimatedDeliveryDate;
-            if (!deliveryDateStr) return '';
-            
-            // 解析发货日期
-            const deliveryDate = new Date(deliveryDateStr);
-            if (isNaN(deliveryDate.getTime())) return '';
-            
-            // 获取产品数据中的 shipping_info
-            if (!this.productData) return deliveryDateStr;
-            
-            const productData = this.productData;
-            let shippingDays = 5;
-            
-            // 检查是否勾选了 Sample Order 复选框
-            const sampleCheckbox = document.querySelector('.sample-check input#sample');
-            const isSampleOrder = sampleCheckbox && sampleCheckbox.checked;
-            
-            // 从 API 数据中获取 shipping_info
-            if (productData && productData.product && productData.product.data && productData.product.data.shipping_info) {
-                const shippingInfo = productData.product.data.shipping_info;
-                
-                if (isSampleOrder && shippingInfo.rts_for_sample_order) {
-                    shippingDays = Number(shippingInfo.rts_for_sample_order) || 0;
-                } else if (!isSampleOrder && shippingInfo.rts_for_bulk_order) {
-                    shippingDays = Number(shippingInfo.rts_for_bulk_order) || 0;
-                }
-            }
-            
-            // 如果没有从 API 数据获取到，使用默认值
-            if (shippingDays === 0) {
-                if (isSampleOrder) {
-                    shippingDays = 1; // 样品订单默认1天运输时间
-                } else {
-                    shippingDays = 2; // 批量订单默认2天运输时间
-                }
-            }
-            
-            // 计算到货日期
-            const arrivalDate = new Date(deliveryDate);
-            arrivalDate.setDate(deliveryDate.getDate() + shippingDays);
-            
-            // 格式化日期为 YYYY-MM-DD 格式
-            const year = arrivalDate.getFullYear();
-            const month = String(arrivalDate.getMonth() + 1).padStart(2, '0');
-            const day = String(arrivalDate.getDate()).padStart(2, '0');
-            
-            return `${year}-${month}-${day}`;
-        },
-        
-        // ===== 新增：计算起订量（MOQ） =====
-        // 计算最终的起订量，取颜色MOQ和印刷方式MOQ的最大值
-        getCalculatedMoq: (state) => {
-            let maxColorMoq = 0;
-            let maxPrintMethodMoq = 0;
-            
-            // 1. 从 selectedColorsByView 中获取颜色相关的 MOQ
-            const colorsMap = state.selectedColorsByView || {};
-            for (const viewId in colorsMap) {
-                if (!Object.prototype.hasOwnProperty.call(colorsMap, viewId)) continue;
-                const colorData = colorsMap[viewId];
-                if (!colorData || !colorData.moq_setting) continue;
-                
-                // 处理嵌套的 _custom.value 结构
-                let moqSetting = colorData.moq_setting;
-                if (moqSetting._custom && moqSetting._custom.value) {
-                    moqSetting = moqSetting._custom.value;
-                }
-                
-                // 检查 enable 状态（兼容多种布尔表示）
-                const moqEnabled = moqSetting.enable === true || moqSetting.enable === 1 || 
-                                 moqSetting.enable === '1' || moqSetting.enable === 'true';
-                if (!moqEnabled) continue;
-                
-                const qty = Number(moqSetting.minimum_order_quantity);
-                if (Number.isFinite(qty) && qty > maxColorMoq) {
-                    maxColorMoq = qty;
-                }
-            }
-            
-            // 2. 从 usedPrintMethodsByView 中获取印刷方式相关的 MOQ
-            const printMethodStore = window.usePrintMethodStore && window.usePrintMethodStore();
-            if (printMethodStore && printMethodStore.usedPrintMethodsByView) {
-                const usedPrintMethodsByView = printMethodStore.usedPrintMethodsByView || {};
-                
-                for (const viewId in usedPrintMethodsByView) {
-                    if (!Object.prototype.hasOwnProperty.call(usedPrintMethodsByView, viewId)) continue;
-                    const methodsMap = usedPrintMethodsByView[viewId] || {};
-                    
-                    for (const methodId in methodsMap) {
-                        if (!Object.prototype.hasOwnProperty.call(methodsMap, methodId)) continue;
-                        const method = methodsMap[methodId];
-                        if (!method || !method.apiData) continue;
-                        
-                        const api = method.apiData;
-                        // 检查 moq_enabled 状态（兼容多种布尔表示）
-                        const moqEnabled = api.moq_enabled === true || api.moq_enabled === 1 || 
-                                         api.moq_enabled === '1' || api.moq_enabled === 'true';
-                        if (!moqEnabled) continue;
-                        
-                        const qty = Number(api.moq_quantity);
-                        if (Number.isFinite(qty) && qty > maxPrintMethodMoq) {
-                            maxPrintMethodMoq = qty;
-                        }
-                    }
-                }
-            }
-            
-            // 3. 返回两个值中的最大值，如果都为0则返回1作为默认值
-            const finalMoq = Math.max(maxColorMoq, maxPrintMethodMoq);
-            return finalMoq > 0 ? finalMoq : 1;
-        },
-        
-        // ===== 新增：计算批数量 =====
-        // 根据产品数据中的 sell_in_batch 设置返回批数量
-        getBatchQuantity: (state) => {
-            // 检查 productData 是否存在
-            if (!state.productData) {
-                return 1;
-            }
-            
-            // 检查 productData.product 是否存在
-            const product = state.productData.product.data;
-            if (!product) {
-                return 1;
-            }
-            
-            // 检查 sell_in_batch 是否为 true
-            if (product.sell_in_batch === true) {
-                // 如果按批次销售，返回 batch_quantity
-                if (product.sell_in_batch_info && product.sell_in_batch_info.batch_quantity) {
-                    const batchQty = Number(product.sell_in_batch_info.batch_quantity);
-                    return Number.isFinite(batchQty) && batchQty > 0 ? batchQty : 1;
-                }
-                // 兼容旧的数据结构，直接从 product 中获取 batch_quantity
-                if (product.batch_quantity) {
-                    const batchQty = Number(product.batch_quantity);
-                    return Number.isFinite(batchQty) && batchQty > 0 ? batchQty : 1;
-                }
-            }
-            
-            // 默认返回 1
-            return 1;
-        }
     },
     // 5. actions 定义所有修改 state 的方法（类似于 class 的成员方法）
     actions: {
-        // 设置数量
-        setQuantity(newValue) {
-            this.quantity = Math.max(1, newValue);
-        },
-
-        // 设置Sample Order状态
-        setIsSampleOrder(value) {
-            this.isSampleOrder = Boolean(value);
-        },
-
-        // 切换Sample Order状态
-        toggleSampleOrder() {
-            this.isSampleOrder = !this.isSampleOrder;
-        },
-
         // 切换当前激活的画板
         setActiveCanvasId(id) { this.activeCanvasId = id; },
         // 更新指定画板的状态（如对象、图层等）
@@ -569,12 +293,6 @@ export const useCanvasStore = defineStore('canvas', {
                 this.setLoadingProductData(false);
             }
         },
-        // 更新预期到货日期（发货日期现在是自动计算的）
-        updateEstimatedDates(deliveryDate, arrivalDate) {
-            // estimatedDeliveryDate 现在是计算属性，不需要手动设置
-            if (arrivalDate) this.estimatedArrivalDate = arrivalDate;
-        },
-
         // 从产品数据中提取视图信息
         extractViewsFromProductData(productData) {
             const views = [];


### PR DESCRIPTION
## Summary
- move product-card-footer specific state, getters, and actions from the shared canvas store into the component with detailed Chinese documentation
- rebuild the footer component around local reactive state to calculate MOQ, pricing, quantity, and estimated dates while syncing the sample-order checkbox
- simplify the canvas store by removing footer-only fields and methods so other components remain unaffected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68fcc704f144832190fb443ba46db1ae