### PR TITLE
Cache content area masks for 4-grid compositing

### DIFF
--- a/public/js/design/stores/index.js
+++ b/public/js/design/stores/index.js
@@ -39,6 +39,9 @@ export const useCanvasStore = defineStore('canvas', {
         // ===== 新增：按视图记录用户选择的颜色（来源于 variants.data 的颜色） =====
         // 结构：{ [viewId]: 完整的变体对象 (包含API返回的所有字段) + selectedColor }
         selectedColorsByView: {},
+        // ===== 新增：缓存每个视图的内容区域PNG结果 =====
+        // 结构：{ [viewId]: { dataURL, width, height, clipRect } }
+        contentAreaImagesByView: {},
     }),
     // 4. getters 定义依赖状态的计算逻辑（所有依赖 Store 状态的计算放在这里）
     getters: {
@@ -271,6 +274,11 @@ export const useCanvasStore = defineStore('canvas', {
         // 清除所有视图的选中颜色
         clearAllSelectedColors() {
             this.selectedColorsByView = {};
+        },
+        // ===== 新增：缓存内容区域图像 =====
+        setContentAreaImage(viewId, imageData) {
+            if (!viewId) return;
+            this.contentAreaImagesByView[viewId] = imageData;
         },
         // 异步获取产品数据
         async fetchProductData(pwId) {

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -2406,26 +2406,34 @@ async function generate4GridImagesForView(view) {
         }
     }
 
-    // 获取当前视图的画布而不是激活的画布
-    let activeCanvas = null;
+    const canvasStore = typeof window.useCanvasStore === 'function' ? window.useCanvasStore() : null;
+    const contentAreaImage = canvasStore?.contentAreaImagesByView?.[view.id] || null;
+
+    let designCanvasDataURL = null;
     if (window.CanvasManager && view.id) {
-        activeCanvas = window.CanvasManager.getCanvas(view.id);
+        const designCanvas = window.CanvasManager.getCanvas(view.id);
+        if (!designCanvas) {
+            console.warn('Active canvas not found for view:', view.id);
+        } else {
+            try {
+                designCanvasDataURL = designCanvas.toDataURL('image/png');
+            } catch (error) {
+                console.warn('Failed to export design canvas as dataURL:', error);
+            }
+        }
     }
 
-    // 如果无法获取特定视图的画布，回退到原来的getActiveCanvas方法
-    if (! activeCanvas) {
-        activeCanvas = getActiveCanvas();
-    }
-
-    if (! activeCanvas) {
-        console.error('No active canvas found for 4-grid generation');
+    if (!contentAreaImage && !designCanvasDataURL) {
+        console.error('No content area image or design data found for 4-grid generation');
         return [
-            'data:image/svg+xml;base64,' + btoa('<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#ffe6e6"/><text x="50%" y="50%" text-anchor="middle" dy=".3em" fill="#cc0000">无法获取画布</text></svg>'),
-            'data:image/svg+xml;base64,' + btoa('<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#ffe6e6"/><text x="50%" y="50%" text-anchor="middle" dy=".3em" fill="#cc0000">无法获取画布</text></svg>'),
-            'data:image/svg+xml;base64,' + btoa('<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#ffe6e6"/><text x="50%" y="50%" text-anchor="middle" dy=".3em" fill="#cc0000">无法获取画布</text></svg>'),
-            'data:image/svg+xml;base64,' + btoa('<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#ffe6e6"/><text x="50%" y="50%" text-anchor="middle" dy=".3em" fill="#cc0000">无法获取画布</text></svg>')
+            'data:image/svg+xml;base64,' + btoa('<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#ffe6e6"/><text x="50%" y="50%" text-anchor="middle" dy=".3em" fill="#cc0000">缺少内容区域</text></svg>'),
+            'data:image/svg+xml;base64,' + btoa('<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#ffe6e6"/><text x="50%" y="50%" text-anchor="middle" dy=".3em" fill="#cc0000">缺少内容区域</text></svg>'),
+            'data:image/svg+xml;base64,' + btoa('<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#ffe6e6"/><text x="50%" y="50%" text-anchor="middle" dy=".3em" fill="#cc0000">缺少内容区域</text></svg>'),
+            'data:image/svg+xml;base64,' + btoa('<svg width="200" height="200" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#ffe6e6"/><text x="50%" y="50%" text-anchor="middle" dy=".3em" fill="#cc0000">缺少内容区域</text></svg>')
         ];
     }
+
+    const fallbackFillColor = contentAreaImage?.fillColor || getExplicitSelectedColor() || '#FFFFFF';
 
     // 定义4个视图的配置（裁剪参数）
     const viewConfigs = [
@@ -2486,8 +2494,10 @@ async function generate4GridImagesForView(view) {
                 baseLayer,
                 overlayLayer,
                 mappingLayer,
-                activeCanvas,
-                cropConfig: config.cropConfig
+                contentAreaImage,
+                designImageData: designCanvasDataURL,
+                cropConfig: config.cropConfig,
+                fallbackFillColor
             });
             gridImages.push(imageData);
         } catch (error) {
@@ -2586,8 +2596,10 @@ async function generateCompositeImageForGrid(options) {
         baseLayer,
         overlayLayer,
         mappingLayer,
-        activeCanvas,
-        cropConfig
+        contentAreaImage,
+        designImageData,
+        cropConfig,
+        fallbackFillColor
     } = options;
 
     // 创建临时画布
@@ -2606,7 +2618,7 @@ async function generateCompositeImageForGrid(options) {
 
         // 2. 绘制Base Layer（如果存在）并应用当前选中的颜色
         if (baseLayer && baseLayer.layer_data && baseLayer.layer_data.content && baseLayer.layer_data.content.imageURL) {
-            const explicitColor = getExplicitSelectedColor();
+            const explicitColor = getExplicitSelectedColor() || fallbackFillColor;
             if (explicitColor) {
                 // 有明确选中的颜色，应用颜色
                 await drawLayerImageForGridWithColor(ctx, baseLayer.layer_data.content.imageURL, canvasWidth, canvasHeight, explicitColor);
@@ -2621,9 +2633,15 @@ async function generateCompositeImageForGrid(options) {
             await drawLayerImageForGrid(ctx, overlayLayer.layer_data.content.imageURL, canvasWidth, canvasHeight);
         }
 
-        // 4. 绘制当前激活画布的裁剪区域，实现窗户效果
-        if (activeCanvas) {
-            await drawCroppedCanvasRegionWithWindowEffect(ctx, activeCanvas, cropConfig, canvasWidth, canvasHeight);
+        // 4. 使用缓存的内容区域PNG与设计图合成后绘制
+        const maskedCanvas = await createMaskedCanvasForGrid({
+            contentAreaImage,
+            designImageData,
+            fallbackFillColor
+        });
+
+        if (maskedCanvas) {
+            await drawCroppedCanvasRegionWithWindowEffect(ctx, maskedCanvas, cropConfig, canvasWidth, canvasHeight);
         }
 
         return tempCanvas.toDataURL('image/png');
@@ -2631,6 +2649,54 @@ async function generateCompositeImageForGrid(options) {
         console.error('Error generating composite image for grid:', error);
         throw error;
     }
+}
+
+async function createMaskedCanvasForGrid({ contentAreaImage, designImageData, fallbackFillColor }) {
+    if (!contentAreaImage || !contentAreaImage.dataURL) {
+        return null;
+    }
+
+    try {
+        const maskImage = await loadImageElementForGrid(contentAreaImage.dataURL);
+        const maskedCanvas = document.createElement('canvas');
+        maskedCanvas.width = maskImage.width;
+        maskedCanvas.height = maskImage.height;
+        const maskedCtx = maskedCanvas.getContext('2d');
+
+        maskedCtx.clearRect(0, 0, maskedCanvas.width, maskedCanvas.height);
+        maskedCtx.drawImage(maskImage, 0, 0, maskedCanvas.width, maskedCanvas.height);
+        maskedCtx.globalCompositeOperation = 'source-in';
+
+        if (designImageData) {
+            try {
+                const designImage = await loadImageElementForGrid(designImageData);
+                maskedCtx.drawImage(designImage, 0, 0, maskedCanvas.width, maskedCanvas.height);
+            } catch (error) {
+                console.warn('Failed to load design image for masking, using fallback color.', error);
+                maskedCtx.fillStyle = fallbackFillColor || contentAreaImage.fillColor || '#FFFFFF';
+                maskedCtx.fillRect(0, 0, maskedCanvas.width, maskedCanvas.height);
+            }
+        } else {
+            maskedCtx.fillStyle = fallbackFillColor || contentAreaImage.fillColor || '#FFFFFF';
+            maskedCtx.fillRect(0, 0, maskedCanvas.width, maskedCanvas.height);
+        }
+
+        maskedCtx.globalCompositeOperation = 'source-over';
+        return maskedCanvas;
+    } catch (error) {
+        console.warn('Failed to create masked canvas for grid preview:', error);
+        return null;
+    }
+}
+
+function loadImageElementForGrid(src) {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.crossOrigin = 'anonymous';
+        img.onload = () => resolve(img);
+        img.onerror = reject;
+        img.src = src;
+    });
 }
 
 /**

--- a/public/partials/canvas-design_area.php
+++ b/public/partials/canvas-design_area.php
@@ -797,6 +797,60 @@ if ($first_image_url) {
     }
 
     /**
+     * 以跨域方式加载图片资源。
+     * @param {string} src - 图片地址。
+     * @returns {Promise<HTMLImageElement>} 图片元素。
+     */
+    function loadImageElement(src) {
+        return new Promise((resolve, reject) => {
+            const img = new Image();
+            img.crossOrigin = 'anonymous';
+            img.onload = () => resolve(img);
+            img.onerror = reject;
+            img.src = src;
+        });
+    }
+
+    /**
+     * 根据图层数据提取内容区域的裁剪矩形信息。
+     * @param {Object} layer - 图层数据。
+     * @returns {{left:number,top:number,width:number,height:number}|null}
+     */
+    function extractClipRectFromLayer(layer) {
+        try {
+            const data = layer?.layer_data;
+            if (!data || !data.position || !data.dimensions) {
+                return null;
+            }
+
+            const dimensions = data.dimensions.contentArea || data.dimensions.layerSize;
+            if (!dimensions || !dimensions.width || !dimensions.height) {
+                return null;
+            }
+
+            const origins = getOriginFromAnchorPoint(data.position.anchorPoint || 'top-left');
+            const convertedCoords = convertCoordinatesForOrigin(
+                data.position.coordinates?.x || 0,
+                data.position.coordinates?.y || 0,
+                dimensions.width,
+                dimensions.height,
+                origins.originX,
+                origins.originY
+            );
+
+            return {
+                left: convertedCoords.x,
+                top: convertedCoords.y,
+                width: dimensions.width,
+                height: dimensions.height
+            };
+        } catch (error) {
+            console.warn('无法从图层中解析裁剪信息：', error);
+            return null;
+        }
+    }
+
+    /**
      * 清除指定视图主画布上的内容区域裁剪限制。
      * @param {number|string} viewId - 视图 ID。
      */
@@ -861,59 +915,59 @@ if ($first_image_url) {
     async function handleFourGridContentArea(view) {
         const viewLayers = view?.data?.layer_config?.layers;
         if (!Array.isArray(viewLayers) || viewLayers.length === 0) {
+            clearContentAreaClip(view.id);
             return;
         }
 
-        const baseCanvasElement = document.getElementById(`baseCanvas-${view.id}`);
         const mainCanvasElement = document.getElementById(`mainCanvas-${view.id}`);
-        if (!baseCanvasElement || !baseCanvasElement.__fabricCanvas || !mainCanvasElement || !mainCanvasElement.__fabricCanvas) {
-            console.warn('未能获取到 4-Grid Flow 视图的 baseCanvas 或 mainCanvas。');
+        if (!mainCanvasElement || !mainCanvasElement.__fabricCanvas) {
+            console.warn('未能获取到 4-Grid Flow 视图的 mainCanvas。');
             return;
         }
 
-        const baseCanvas = baseCanvasElement.__fabricCanvas;
+        const store = typeof window.useCanvasStore === 'function' ? window.useCanvasStore() : null;
+        const hasContentLayer = viewLayers.some(layer => layer && layer.name === 'Content Area Layer');
+        const cachedContent = store?.contentAreaImagesByView?.[view.id];
+
+        if (!hasContentLayer) {
+            if (store && typeof store.setContentAreaImage === 'function') {
+                store.setContentAreaImage(view.id, null);
+            }
+            clearContentAreaClip(view.id);
+            return;
+        }
+
+        if (!cachedContent || !cachedContent.dataURL) {
+            console.warn('未在 Pinia 中找到内容区域缓存 PNG，将跳过裁剪处理。');
+            clearContentAreaClip(view.id);
+            return;
+        }
+
+        const clipData = cachedContent.clipRect;
         const mainCanvas = mainCanvasElement.__fabricCanvas;
 
-        // 先移除旧的内容区域图层，避免重复叠加。
-        const existingContentArea = baseCanvas.getObjects().filter(obj => obj && obj.name === 'Content Area Layer');
-        if (existingContentArea.length > 0) {
-            existingContentArea.forEach(obj => baseCanvas.remove(obj));
-            baseCanvas.renderAll();
-        }
-
-        const contentAreaLayer = viewLayers.find(layer => layer.name === 'Content Area Layer');
-        if (!contentAreaLayer) {
-            clearContentAreaClip(view.id);
-            return;
-        }
-
-        const imageURL = contentAreaLayer?.layer_data?.content?.imageURL;
-        if (!isValidImageURL(imageURL)) {
-            console.warn('Content Area Layer 不包含可用的图片资源，将跳过渲染与裁剪。');
-            clearContentAreaClip(view.id);
-            return;
-        }
-
-        try {
-            const contentAreaObject = await createFabricObjectFromLayer(baseCanvas, contentAreaLayer);
-            if (!contentAreaObject) {
-                clearContentAreaClip(view.id);
-                return;
-            }
-
-            contentAreaObject.set({
+        if (clipData && typeof fabric !== 'undefined') {
+            const clipRect = new fabric.Rect({
+                left: clipData.left,
+                top: clipData.top,
+                width: clipData.width,
+                height: clipData.height,
+                originX: 'left',
+                originY: 'top',
+                absolutePositioned: true,
                 selectable: false,
-                evented: false,
-                name: 'Content Area Layer'
+                evented: false
             });
 
-            baseCanvas.add(contentAreaObject);
-            baseCanvas.bringToFront(contentAreaObject);
-            baseCanvas.renderAll();
-
-            applyContentAreaClip(mainCanvas, contentAreaObject);
-        } catch (error) {
-            console.error('渲染 Content Area Layer 时发生错误:', error);
+            mainCanvas.clipPath = clipRect;
+            mainCanvas.__contentAreaClipRect = clipRect;
+            if (typeof mainCanvas.requestRenderAll === 'function') {
+                mainCanvas.requestRenderAll();
+            } else if (typeof mainCanvas.renderAll === 'function') {
+                mainCanvas.renderAll();
+            }
+        } else {
+            console.warn('未能从缓存的内容区域图像中解析裁剪信息，将清除现有裁剪。');
             clearContentAreaClip(view.id);
         }
     }
@@ -990,6 +1044,86 @@ if ($first_image_url) {
     async function renderLayerToSpecificCanvas(canvas, layer, store, view) {
         if (!canvas || !layer) {
             console.error("渲染单个图层需要有效的画布实例和图层数据。");
+            return null;
+        }
+
+        if (layer.name === 'Content Area Layer') {
+            const viewId = view?.id;
+            const imageURL = layer?.layer_data?.content?.imageURL;
+
+            if (!isValidImageURL(imageURL)) {
+                if (store && typeof store.setContentAreaImage === 'function') {
+                    store.setContentAreaImage(viewId, null);
+                }
+                return null;
+            }
+
+            try {
+                const imageElement = await loadImageElement(imageURL);
+                const offscreenCanvas = document.createElement('canvas');
+                const width = imageElement.naturalWidth || imageElement.width;
+                const height = imageElement.naturalHeight || imageElement.height;
+
+                if (!width || !height) {
+                    throw new Error('Content Area PNG 尺寸异常。');
+                }
+
+                offscreenCanvas.width = width;
+                offscreenCanvas.height = height;
+                const offscreenCtx = offscreenCanvas.getContext('2d');
+
+                offscreenCtx.clearRect(0, 0, width, height);
+                offscreenCtx.drawImage(imageElement, 0, 0, width, height);
+
+                const imageData = offscreenCtx.getImageData(0, 0, width, height);
+                const data = imageData.data;
+                const totalPixels = width * height;
+                let opaquePixels = 0;
+                const alphaThreshold = 32;
+
+                for (let i = 0; i < data.length; i += 4) {
+                    if (data[i + 3] >= alphaThreshold) {
+                        opaquePixels++;
+                    }
+                }
+
+                const opaqueRatio = opaquePixels / Math.max(totalPixels, 1);
+                const isLineArt = opaqueRatio <= 0.2;
+
+                const colorData = store?.getSelectedColorByView ? store.getSelectedColorByView(viewId) : (store?.selectedColorsByView?.[viewId]);
+                const fallbackColor = '#FFFFFF';
+                const baseColor = colorData?.selectedColor || colorData?.color || fallbackColor;
+
+                if (isLineArt) {
+                    offscreenCtx.clearRect(0, 0, width, height);
+                    offscreenCtx.fillStyle = baseColor;
+                    offscreenCtx.fillRect(0, 0, width, height);
+                    offscreenCtx.globalCompositeOperation = 'source-in';
+                    offscreenCtx.drawImage(imageElement, 0, 0, width, height);
+                    offscreenCtx.globalCompositeOperation = 'source-over';
+                } else {
+                    offscreenCtx.clearRect(0, 0, width, height);
+                    offscreenCtx.drawImage(imageElement, 0, 0, width, height);
+                }
+
+                const clipRect = extractClipRectFromLayer(layer);
+                if (store && typeof store.setContentAreaImage === 'function') {
+                    store.setContentAreaImage(viewId, {
+                        dataURL: offscreenCanvas.toDataURL('image/png'),
+                        width,
+                        height,
+                        clipRect,
+                        fillColor: baseColor,
+                        isLineArt
+                    });
+                }
+            } catch (error) {
+                console.error('处理 Content Area Layer PNG 时发生错误：', error);
+                if (store && typeof store.setContentAreaImage === 'function') {
+                    store.setContentAreaImage(viewId, null);
+                }
+            }
+
             return null;
         }
 


### PR DESCRIPTION
## Summary
- store processed content area PNGs per view in the canvas Pinia store
- preprocess content area layers offscreen and reuse cached data to clip 4-grid canvases
- refactor 4-grid image generation to mask designs with the cached content area artwork instead of the live canvas

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68ff0f2b3e288321817b0de7f5685c13