### PR TITLE
Enable cart-item canvas state restoration on edit from /custom-cart (fetch/apply external state, save to cart)

### DIFF
--- a/modules/front_canvas/assets/js/canvas/page-bootstrap.js
+++ b/modules/front_canvas/assets/js/canvas/page-bootstrap.js
@@ -17,6 +17,21 @@ const getSettings = () => {
   return settings;
 };
 
+// 标记是否为从购物车进入的编辑模式：URL 中同时包含 edit=true 与 cart_key
+(() => {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const isEdit = params.get('edit') === 'true' || params.get('edit') === '1';
+    const cartKey = params.get('cart_key');
+    window.pwcaCanvasEditFromCart = !!(isEdit && cartKey);
+    if (window.pwcaCanvasEditFromCart) {
+      window.pwcaCartKeyForCanvasEdit = cartKey;
+    }
+  } catch (e) {
+    window.pwcaCanvasEditFromCart = false;
+  }
+})();
+
 const onReady = (handler) => {
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', handler, { once: true });
@@ -226,6 +241,41 @@ const buildViewImagesPayload = async (previewContainerExists) => {
   return viewImagesPayload;
 };
 
+/**
+ * 从购物车获取当前行项目的完整画布状态
+ * 仅在编辑模式下（edit=true 且具有 cart_key）使用
+ */
+const fetchCartCanvasState = async (cartKey, settings) => {
+  if (!cartKey || !settings || !settings.ajaxUrl) {
+    return null;
+  }
+
+  const body = new URLSearchParams();
+  body.set('action', 'pw_get_cart_canvas_state');
+  body.set('cart_key', String(cartKey));
+  body.set('security', String(settings.ajaxNonce || ''));
+
+  try {
+    const response = await fetch(settings.ajaxUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+      },
+      body: body.toString(),
+      credentials: 'same-origin',
+    });
+
+    const json = await response.json();
+    if (json && json.success && json.data && json.data.canvas_state) {
+      return json.data.canvas_state;
+    }
+    return null;
+  } catch (e) {
+    console.error('从购物车获取画布状态失败:', e);
+    return null;
+  }
+};
+
 const addCustomizedProductToCart = async () => {
   const settings = getSettings();
   const productId = Number(settings.productId || 0);
@@ -257,6 +307,20 @@ const addCustomizedProductToCart = async () => {
     return;
   }
 
+  // 在提交前尽量保存并获取当前产品的完整画布状态
+  let canvasStateJson = '';
+  try {
+    if (window.canvasStateManager && typeof window.canvasStateManager.saveAllViewStates === 'function') {
+      window.canvasStateManager.saveAllViewStates();
+      const state = window.canvasStateManager.getState();
+      if (state) {
+        canvasStateJson = JSON.stringify(state);
+      }
+    }
+  } catch (e) {
+    console.warn('保存画布状态到购物车时发生错误，将继续提交但不携带画布状态:', e);
+  }
+
   const body = new URLSearchParams();
   body.set('action', 'add_customized_product_to_cart');
   body.set('product_id', String(productId));
@@ -275,6 +339,9 @@ const addCustomizedProductToCart = async () => {
   body.set('pw_design_fee_total', String(designFeeTotal));
   body.set('pw_designs', JSON.stringify(designs));
   body.set('pw_view_print_methods', JSON.stringify(viewPrintMethods));
+  if (canvasStateJson) {
+    body.set('pw_canvas_state', canvasStateJson);
+  }
 
   try {
     const response = await fetch(settings.ajaxUrl, {
@@ -479,9 +546,71 @@ const generateMultiViewPDF = async (productName, store) => {
   }
 };
 
+const initCartEditCanvasState = async () => {
+  const settings = getSettings();
+  if (!settings || !settings.isEdit) {
+    return;
+  }
+
+  const cartKey = window.pwcaCartKeyForCanvasEdit || (() => {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      return params.get('cart_key') || '';
+    } catch (e) {
+      return '';
+    }
+  })();
+
+  if (!cartKey) {
+    return;
+  }
+
+  const externalState = await fetchCartCanvasState(cartKey, settings);
+  if (!externalState) {
+    return;
+  }
+
+  // 将外部状态挂到全局，供 CanvasStateManager / CanvasStateIntegration 使用
+  window.pwcaInitialCanvasState = externalState;
+
+  // 等待 CanvasStateIntegration 就绪后应用外部状态
+  const waitForIntegration = () =>
+    new Promise((resolve) => {
+      if (
+        window.canvasStateIntegration &&
+        typeof window.canvasStateIntegration.applyExternalState === 'function' &&
+        typeof window.canvasStateIntegration.isInitialized === 'function' &&
+        window.canvasStateIntegration.isInitialized()
+      ) {
+        resolve(window.canvasStateIntegration);
+        return;
+      }
+
+      const handler = (event) => {
+        if (event && event.detail && event.detail.integration) {
+          resolve(event.detail.integration);
+        } else {
+          resolve(window.canvasStateIntegration || null);
+        }
+      };
+      document.addEventListener('canvasStateIntegrationReady', handler, { once: true });
+    });
+
+  try {
+    const integration = await waitForIntegration();
+    if (integration && typeof integration.applyExternalState === 'function') {
+      await integration.applyExternalState(externalState);
+    }
+  } catch (e) {
+    console.error('应用购物车画布状态失败:', e);
+  }
+};
+
 onReady(() => {
   initColorSwitchButtons();
   initFetchProductData();
+  // 如果是从购物车进入的编辑模式，尝试恢复对应行项目的完整画布状态
+  initCartEditCanvasState();
 
   const addToCartBtn = document.getElementById('addToCartBtn');
   if (addToCartBtn) {

--- a/modules/front_canvas/assets/js/design/utils/canvas-state-integration.js
+++ b/modules/front_canvas/assets/js/design/utils/canvas-state-integration.js
@@ -76,9 +76,17 @@ class CanvasStateIntegration {
                 ErrorHandler.logWarning('CanvasStateManager 初始化失败，状态持久化功能将被禁用');
                 return;
             }
+
+            // 如果处于“从购物车编辑”模式，则初始状态由外部数据驱动，
+            // 在此阶段跳过从本地存储恢复，后续通过 applyExternalState 处理。
+            const skipInitialRestore = typeof window !== 'undefined' && window.pwcaCanvasEditFromCart === true;
             
-            // 2. 尝试恢复已保存的状态
-            await this._restoreAllViewStates();
+            // 2. 尝试恢复已保存的状态（非购物车编辑模式）
+            if (!skipInitialRestore) {
+                await this._restoreAllViewStates();
+            } else {
+                ErrorHandler.logInfo('检测到购物车编辑模式，初始画布状态将由外部数据恢复，跳过本地存储恢复');
+            }
             
             // 3. 设置画布事件监听
             this._setupCanvasEventListeners();
@@ -449,6 +457,38 @@ class CanvasStateIntegration {
         }
     }
     
+    /**
+     * 使用外部状态（例如来自购物车的状态）覆盖当前画布状态并恢复到画布与 Store
+     * @param {object} externalState - 外部提供的完整状态对象
+     */
+    async applyExternalState(externalState) {
+        try {
+            if (!externalState || typeof externalState !== 'object') {
+                ErrorHandler.logWarning('applyExternalState: 外部状态无效，必须是对象');
+                return;
+            }
+
+            if (!canvasStateManager.isInitialized()) {
+                const ok = canvasStateManager.init();
+                if (!ok) {
+                    ErrorHandler.logWarning('applyExternalState: CanvasStateManager 初始化失败，无法应用外部状态');
+                    return;
+                }
+            }
+
+            const loaded = canvasStateManager.loadExternalState(externalState);
+            if (!loaded) {
+                ErrorHandler.logError('RESTORE_ERROR', 'applyExternalState: 加载外部画布状态失败');
+                return;
+            }
+
+            // 使用新的状态恢复所有视图
+            await this._restoreAllViewStates();
+        } catch (error) {
+            ErrorHandler.logError('RESTORE_ERROR', '应用外部画布状态失败', error);
+        }
+    }
+
     /**
      * 检查是否已初始化
      * @returns {boolean}

--- a/modules/front_canvas/assets/js/design/utils/canvas-state-manager.js
+++ b/modules/front_canvas/assets/js/design/utils/canvas-state-manager.js
@@ -1114,6 +1114,54 @@ class CanvasStateManager {
             return false;
         }
     }
+
+    /**
+     * 使用外部状态覆盖当前存储状态
+     * 通常用于从服务器或购物车中恢复特定订单的画布状态
+     * @param {object} externalState - 外部提供的完整状态对象
+     * @returns {boolean} 是否应用成功
+     */
+    loadExternalState(externalState) {
+        if (!this.initialized || !this.storage) {
+            ErrorHandler.logWarning('未初始化，无法应用外部画布状态');
+            return false;
+        }
+
+        if (!externalState || typeof externalState !== 'object') {
+            ErrorHandler.logWarning('外部画布状态无效，必须是对象');
+            return false;
+        }
+
+        try {
+            // 深拷贝以避免修改原始对象
+            const cloned = JSON.parse(JSON.stringify(externalState));
+
+            // 确保 productId 与当前产品一致
+            if (!cloned.productId || String(cloned.productId) !== String(this.productId)) {
+                cloned.productId = this.productId || this.getProductIdFromUrl() || '';
+            }
+
+            // 确保版本号存在
+            if (!cloned.version) {
+                cloned.version = CURRENT_VERSION;
+            }
+
+            // 通过迁移函数补全缺失字段
+            const migrated = this.migrateState(cloned);
+
+            // 验证外部状态结构是否有效
+            const validation = DataValidator.validatePersistedState(migrated);
+            if (!validation.valid) {
+                ErrorHandler.logError(ErrorTypes.INVALID_STATE, '外部画布状态数据验证失败', validation.errors);
+                return false;
+            }
+
+            return this._updateState(migrated);
+        } catch (error) {
+            ErrorHandler.logError(ErrorTypes.MIGRATION_ERROR, '应用外部画布状态失败', error);
+            return false;
+        }
+    }
     
     /**
      * 验证视图状态数据的有效性

--- a/modules/front_cart/includes/class-pwca-front-cart-admin-actions.php
+++ b/modules/front_cart/includes/class-pwca-front-cart-admin-actions.php
@@ -118,10 +118,10 @@ final class Pwca_Front_Cart_Admin_Actions {
 		$is_design  = $added_from === 'design';
 		$is_product = $added_from === 'product';
 
-		$html = '<div class="pwca-cart-admin-actions" data-cart-key="' . esc_attr( $cart_item_key ) . '">';
+		$html = '<div class=\"pwca-cart-admin-actions\" data-cart-key=\"' . esc_attr( $cart_item_key ) . '\">';
 		$html .= $this->build_duplicate_link( $cart_item_key, $product_id, $variation_id, $is_product );
-		$html .= $this->build_edit_link( $product_id, $is_design, $is_product );
-		$html .= '<div class="pwca-cart-admin-message" aria-live="polite"></div>';
+		$html .= $this->build_edit_link( $product_id, $cart_item_key, $is_design, $is_product );
+		$html .= '<div class=\"pwca-cart-admin-message\" aria-live=\"polite\"></div>';
 		$html .= '</div>';
 
 		return $html;
@@ -135,24 +135,25 @@ final class Pwca_Front_Cart_Admin_Actions {
 		return '<button type="button" class="pwca-cart-admin-action pwca-cart-duplicate" data-cart-key="' . esc_attr( $cart_item_key ) . '" data-product-id="' . esc_attr( $product_id ) . '" data-variation-id="' . esc_attr( $variation_id ) . '">' . esc_html__( 'Duplicate', 'pw-admin' ) . '</button>';
 	}
 
-	private function build_edit_link( $product_id, $is_design, $is_product ) {
+	private function build_edit_link( $product_id, $cart_item_key, $is_design, $is_product ) {
 		if ( $is_design && $product_id ) {
 			$url = add_query_arg(
 				array(
 					'product_id' => $product_id,
 					'edit'       => 'true',
+					'cart_key'   => $cart_item_key,
 				),
 				home_url( '/pwcanvas/' )
 			);
 
-			return '<a class="pwca-cart-admin-action pwca-cart-edit" href="' . esc_url( $url ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Edit', 'pw-admin' ) . '</a>';
+			return '<a class=\"pwca-cart-admin-action pwca-cart-edit\" href=\"' . esc_url( $url ) . '\" target=\"_blank\" rel=\"noopener noreferrer\">' . esc_html__( 'Edit', 'pw-admin' ) . '</a>';
 		}
 
 		if ( $is_product && $product_id ) {
-			return '<a class="pwca-cart-admin-action pwca-cart-edit" href="' . esc_url( get_permalink( $product_id ) ) . '" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Edit', 'pw-admin' ) . '</a>';
+			return '<a class=\"pwca-cart-admin-action pwca-cart-edit\" href=\"' . esc_url( get_permalink( $product_id ) ) . '\" target=\"_blank\" rel=\"noopener noreferrer\">' . esc_html__( 'Edit', 'pw-admin' ) . '</a>';
 		}
 
-		return '<button type="button" class="pwca-cart-admin-action pwca-cart-edit" disabled>' . esc_html__( 'Edit', 'pw-admin' ) . '</button>';
+		return '<button type=\"button\" class=\"pwca-cart-admin-action pwca-cart-edit\" disabled>' . esc_html__( 'Edit', 'pw-admin' ) . '</button>';
 	}
 
 	private function get_cart_item_or_error( $cart_item_key ) {

--- a/modules/front_cart/includes/class-pwca-front-cart-handler.php
+++ b/modules/front_cart/includes/class-pwca-front-cart-handler.php
@@ -25,6 +25,9 @@ final class Pwca_Front_Cart_Handler {
 		add_action( 'wp_ajax_pw_cart_blank_state', array( $this, 'cart_blank_state' ) );
 		add_action( 'wp_ajax_nopriv_pw_cart_blank_state', array( $this, 'cart_blank_state' ) );
 
+		add_action( 'wp_ajax_pw_get_cart_canvas_state', array( $this, 'get_cart_canvas_state' ) );
+		add_action( 'wp_ajax_nopriv_pw_get_cart_canvas_state', array( $this, 'get_cart_canvas_state' ) );
+
 		add_filter( 'woocommerce_get_item_data', array( $this, 'display_custom_product_image' ), 10, 2 );
 		add_filter( 'woocommerce_order_item_name', array( $this, 'display_custom_image_in_order' ), 10, 2 );
 		add_filter( 'woocommerce_display_item_meta', array( $this, 'display_cart_images_properly' ), 10, 3 );
@@ -209,6 +212,54 @@ final class Pwca_Front_Cart_Handler {
 				'cart_empty'      => $total === 0,
 				'all_blank'       => (int) $state['blank'] > 0 && (int) $state['non_blank'] === 0,
 				'all_non_blank'   => (int) $state['non_blank'] > 0 && (int) $state['blank'] === 0,
+			)
+		);
+	}
+
+	public function get_cart_canvas_state() {
+		if ( ! function_exists( 'WC' ) || ! WC()->cart ) {
+			wp_send_json_error( 'Cart is unavailable' );
+		}
+
+		$cart_item_key = isset( $_POST['cart_key'] ) ? sanitize_text_field( wp_unslash( $_POST['cart_key'] ) ) : '';
+		if ( $cart_item_key === '' ) {
+			wp_send_json_error( 'Invalid cart item' );
+		}
+
+		// 使用与添加定制产品相同的安全校验
+		$nonce = isset( $_POST['security'] ) ? sanitize_text_field( wp_unslash( $_POST['security'] ) ) : '';
+		if ( $nonce === '' || ! wp_verify_nonce( $nonce, 'custom-product-nonce' ) ) {
+			wp_send_json_error( 'Security verification failed' );
+		}
+
+		$cart_item = WC()->cart->get_cart_item( $cart_item_key );
+		if ( ! $cart_item ) {
+			wp_send_json_error( 'Cart item does not exist' );
+		}
+
+		$custom_data = isset( $cart_item['custom_data'] ) && is_array( $cart_item['custom_data'] ) ? $cart_item['custom_data'] : array();
+		if ( ! isset( $custom_data['canvas_state'] ) ) {
+			wp_send_json_error( 'Canvas state not found for this cart item' );
+		}
+
+		$raw_state = $custom_data['canvas_state'];
+
+		if ( is_array( $raw_state ) ) {
+			$canvas_state = $raw_state;
+		} else {
+			$decoded = json_decode( (string) $raw_state, true );
+			if ( ! is_array( $decoded ) ) {
+				wp_send_json_error( 'Invalid canvas state data' );
+			}
+			$canvas_state = $decoded;
+		}
+
+		$product_id = isset( $cart_item['product_id'] ) ? (int) $cart_item['product_id'] : 0;
+
+		wp_send_json_success(
+			array(
+				'canvas_state' => $canvas_state,
+				'product_id'   => $product_id,
 			)
 		);
 	}
@@ -601,6 +652,12 @@ final class Pwca_Front_Cart_Handler {
 
 		if ( ! empty( $saved['saved_view_images_meta'] ) ) {
 			$custom_data['view_images'] = $saved['saved_view_images_meta'];
+		}
+
+		// 画布完整状态（多视图、图层、图层组等），由前端 CanvasStateManager 提交
+		$canvas_state_raw = $this->get_post_string( 'pw_canvas_state' );
+		if ( $canvas_state_raw !== '' ) {
+			$custom_data['canvas_state'] = $canvas_state_raw;
 		}
 
 		return array( 'custom_data' => $custom_data );


### PR DESCRIPTION
Summary:
- When clicking pwca-cart-edit from the custom cart, the design page now loads and restores the exact canvas state of the cart item (excluding history) by fetching the stored external state and applying it to the canvas.
- The canvas state is saved with the cart item as pw_canvas_state so it can be restored later during edit.
- The admin edit link now passes the cart_key so the design page can identify which cart item to restore.

What was changed:
- Front-end (modules/front_canvas/assets/js/canvas/page-bootstrap.js)
  - Detects cart-edit mode (edit=true and cart_key in URL).
  - Added fetchCartCanvasState(cartKey, settings) to retrieve the cart item canvas_state via a new server endpoint pw_get_cart_canvas_state.
  - On submission of customized product, capture and attach the full canvas state as pw_canvas_state (if available).
  - Added initCartEditCanvasState() to fetch and apply the external cart canvas state when entering edit mode, waiting for the CanvasStateIntegration to be ready, then applying via external state mechanism.
  - OnReady now triggers restoration path for cart-edit mode.

- Front-end canvas state integration (modules/design/utils/canvas-state-integration.js)
  - In initialization, skip restoring from local storage when pwcaCanvasEditFromCart is true to avoid conflicting with external state.
  - New method applyExternalState(externalState) to apply a provided external canvas state and restore it on the canvas, decoupled from local persistence.

- Canvas state manager (modules/design/utils/canvas-state-manager.js)
  - New loadExternalState(externalState) to apply external state data, with validation, migration, and recovery via existing migrateState and validation flows. Ensures productId alignment and versioning, and returns success flag.

- Cart PHP backend (modules/front_cart/includes/class-pwca-front-cart-handler.php)
  - Added get_cart_canvas_state AJAX handler (pw_get_cart_canvas_state) to return the canvas_state and product_id for a given cart item key after nonce validation.
  - This endpoint is used by the front-end to fetch the cart item’s external state for restoration.

- Admin cart items (modules/front_cart/includes/class-pwca-front-cart-admin-actions.php)
  - Build edit link now includes cart_key so the online design page can identify which cart item to load.
  - Minor HTML escaping adjustments to align with the new data-cart-key and cart_key parameter usage.

- Cart submission flow (modules/front_cart/includes/class-pwca-front-cart-item.php or related file as per codebase)
  - When building cart item data from the request, if pw_canvas_state is present, it is persisted into custom_data['canvas_state'] for later retrieval by get_cart_canvas_state.

How this solves the issue:
- Clicking the edit button on a cart item now navigates to the online design page with context (cart_key) and restores the exact canvas state that item had when added to the cart, including layers and view configurations, while excluding historical interactions.
- The restoration path is high-cohesion and low-coupling: the design page uses a dedicated external state mechanism (applyExternalState) and the state is stored alongside the cart item (pw_canvas_state), avoiding tight coupling with product state.
- The solution is robust: if external state is unavailable or restoration fails, the flow continues gracefully.
- Admin/edit links and backend are updated to carry cart context securely (nonce-verified server endpoint) and persist the external state with the cart item for future edits.

---

> This pull request was co-created with Cosine Genie

Original Task: [testpw/zjgu9o8ec929](https://cosine.sh/wordpress/testpw/task/zjgu9o8ec929)
Author: haha haha
