### PR TITLE
feat(design): enforce Category Type visibility for admin and frontend design categories

### DIFF
--- a/modules/front_canvas/assets/js/main/operation-panel-design-search.js
+++ b/modules/front_canvas/assets/js/main/operation-panel-design-search.js
@@ -123,4 +123,81 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     });
+
+    /**
+     * 根据当前视图 ID 与分类的 Category Type 控制前台可见性：
+     * - universal/general：所有视图可见
+     * - main_view：仅在 main_view 视图下可见
+     * - product：暂时与 universal 一致（后续可在此扩展按产品/视图精细控制）
+     */
+    const setupCategoryViewFilter = () => {
+        const categoryNodes = document.querySelectorAll('.category-item');
+        if (!categoryNodes.length) {
+            return;
+        }
+
+        const applyVisibility = (activeViewId) => {
+            const viewId = activeViewId || '';
+            categoryNodes.forEach((item) => {
+                const rawType = item.getAttribute('data-category-type') || 'universal';
+                let type = rawType;
+                if (type === 'general' || type === '') {
+                    type = 'universal';
+                }
+
+                // 默认全部显示
+                let shouldShow = true;
+
+                if (type === 'main_view') {
+                    // 仅 main_view 视图显示
+                    shouldShow = viewId === 'main_view' || viewId === '' || viewId === null;
+                }
+
+                // 目前 product 类型按 universal 处理，保留扩展点
+                // if (type === 'product') { ... }
+
+                item.style.display = shouldShow ? '' : 'none';
+            });
+        };
+
+        const waitForStore = () => {
+            if (typeof window.useCanvasStore === 'function') {
+                try {
+                    const store = window.useCanvasStore();
+                    if (store) {
+                        // 初次应用
+                        applyVisibility(store.activeViewId);
+
+                        // 监听视图切换
+                        if (typeof store.$subscribe === 'function') {
+                            store.$subscribe((mutation, state) => {
+                                if (mutation.storeId === 'canvas') {
+                                    applyVisibility(state.activeViewId);
+                                }
+                            });
+                        }
+
+                        return;
+                    }
+                } catch (e) {
+                    // 安静失败，使用下面的退化逻辑
+                }
+            }
+
+            // 如果 Pinia 还未准备好，继续等待
+            window.setTimeout(waitForStore, 150);
+        };
+
+        // 启动等待 Pinia store 的逻辑
+        waitForStore();
+
+        // 退化：若一段时间后仍无 store，则按单视图(main_view)处理
+        window.setTimeout(() => {
+            if (typeof window.useCanvasStore !== 'function') {
+                applyVisibility('main_view');
+            }
+        }, 1500);
+    };
+
+    setupCategoryViewFilter();
 });

--- a/modules/front_canvas/views/partials/canvas-operation-panel-tab-design.php
+++ b/modules/front_canvas/views/partials/canvas-operation-panel-tab-design.php
@@ -48,7 +48,19 @@
         echo '<div id="design-categories-list" class="content-sheji">';
         echo '<div class="list">';
         foreach ($categories as $category) {
-            echo '<div class="category-item">';
+            $raw_type      = get_term_meta($category->term_id, 'category_type', true);
+            $category_type = is_string($raw_type) ? $raw_type : '';
+
+            // 规范化分类类型：默认视为 universal
+            if ($category_type === '') {
+                $category_type = 'universal';
+            } elseif ($category_type === 'general') {
+                $category_type = 'universal';
+            } elseif (! in_array($category_type, array('universal', 'main_view', 'product'), true)) {
+                $category_type = 'universal';
+            }
+
+            echo '<div class="category-item" data-category-type="' . esc_attr($category_type) . '">';
             echo '<div class="category-item-header">';
             // 统一显示图片在标题上面
             echo '<div class="category_name name">' . '<img src="' . MY_PLUGIN_URL . 'assets/images/icons/design.svg" alt="Designs ICON">' . esc_html($category->name) . '</div>';


### PR DESCRIPTION
Summary:
- Implemented Category Type filtering for design categories in both admin and frontend views.
- Admin side now normalizes category_type metadata (universal, main_view, product) and outputs data-category-type attributes for each category item.
- Frontend now dynamically shows/hides categories based on the current view using the Category Type rules, with support for universal, main_view, and a placeholder for product (future extension).

What changed:
- modules/front_canvas/assets/js/main/operation-panel-design-search.js
  - Added setupCategoryViewFilter to control visibility of .category-item elements according to the active view.
  - Logic:
    - universal/general defaults to visible in all views
    - main_view visible only when current view is main_view (or no view)
    - product treated as universal for now (extensible later)
  - Integrates with the Canvas store (useCanvasStore) and subscribes to view changes to re-apply visibility.
  - Fallback: if store isn't ready within a short window or after a timeout, defaults to main_view visibility to avoid blank UI.

- modules/front_canvas/views/partials/canvas-operation-panel-tab-design.php
  - Reads category_type from term meta (category_type) and normalizes values:
    - '' or 'general' -> 'universal'
    - valid values -> themselves
    - invalid values -> 'universal'
  - Outputs data-category-type attribute on each .category-item so the frontend script can apply visibility rules consistently.

Why:
- Keeps frontend category visibility in sync with backend Configurations for a consistent UX, ensuring categories intended for all views (universal) or specific views (main_view) appear accordingly.
- Provides a clear extension point for product-based visibility in the future.

How to test:
- Admin:
  - In the design categories list, set various category_type values (universal, main_view, product, empty, invalid).
  - Ensure the rendered HTML has data-category-type normalized to universal or main_view as appropriate.
- Frontend:
  - Open the design tab (#tab-sheji) and switch between views (e.g., main_view vs others).
  - Verify:
    - universal categories are visible in all views.
    - main_view categories are only visible when the active view is main_view.
    - product categories currently behave as universal (visible in all views) with a note for future refinement.
  - If the Canvas store is unavailable, the UI should default to main_view behavior after a short delay.

Impact:
- No breaking changes to existing UX, but adds dynamic visibility rules and a data attribute for cross-module coordination.

---

> This pull request was co-created with Cosine Genie

Original Task: [testpw/kued0tbi3qmi](https://cosine.sh/wordpress/testpw/task/kued0tbi3qmi)
Author: haha haha
