### PR TITLE
Restore missing styles for Filter Designs and Bulk Update modals in PW Design admin

### DIFF
--- a/modules/admin_design/assets/scss/pwca-admin-design-management.css
+++ b/modules/admin_design/assets/scss/pwca-admin-design-management.css
@@ -193,4 +193,146 @@
   gap: 8px;
   align-items: center;
   cursor: pointer;
+}
+.pwca-admin-design #pw-vue-filter-modal .modal__container,
+.pwca-admin-design #pw-vue-bulk-update-modal .modal__container {
+  max-width: 360px;
+  width: 100%;
+  padding: 20px 24px;
+}
+.pwca-admin-design .pw-filter-search-field {
+  display: flex;
+  align-items: center;
+  padding: 6px 10px;
+  margin-bottom: 15px;
+  border: 1px solid #ccd0d4;
+  border-radius: 4px;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+.pwca-admin-design .pw-filter-search-field input {
+  flex: 1;
+  border: 0;
+  box-shadow: none;
+  outline: 0;
+  padding: 0;
+  font-size: 13px;
+}
+.pwca-admin-design .pw-filter-search-field .dashicons {
+  color: #b4b9be;
+  font-size: 16px;
+}
+.pwca-admin-design .pw-filter-search-field .dashicons-search {
+  margin-right: 6px;
+}
+.pwca-admin-design .pw-filter-search-field .dashicons-no-alt {
+  margin-left: 6px;
+  cursor: pointer;
+}
+.pwca-admin-design .pw-filter-section {
+  margin-top: 12px;
+}
+.pwca-admin-design .pw-filter-section .pw-filter-toggle {
+  margin: 0 0 4px;
+  font-size: 13px;
+  font-weight: 600;
+  color: #444;
+}
+.pwca-admin-design .pw-filter-section .pw-filter-options {
+  padding: 8px 0;
+  border-top: 1px solid #eee;
+}
+.pwca-admin-design .pw-empty {
+  padding: 4px 0;
+  font-style: italic;
+  color: #999;
+}
+.pwca-admin-design .pw-filter-item {
+  padding: 6px 0;
+  border-bottom: 1px solid #f1f1f1;
+}
+.pwca-admin-design .pw-filter-item:last-child {
+  border-bottom: 0;
+}
+.pwca-admin-design .pw-filter-item .pw-filter-item-header {
+  margin-bottom: 4px;
+}
+.pwca-admin-design .pw-filter-item .pw-filter-item-header label {
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+}
+.pwca-admin-design .pw-filter-item .pw-filter-condition {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.pwca-admin-design .pw-filter-item .pw-filter-condition select,
+.pwca-admin-design .pw-filter-item .pw-filter-condition input {
+  flex: 1;
+  max-width: 100%;
+}
+.pwca-admin-design .pw-filter-item .pw-filter-condition select {
+  min-width: 110px;
+}
+.pwca-admin-design .pw-filter-item-available {
+  padding: 4px 0;
+}
+.pwca-admin-design .pw-filter-item-available label {
+  cursor: pointer;
+  font-size: 13px;
+}
+.pwca-admin-design .pw-toggle-switch {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+.pwca-admin-design .pw-toggle-input {
+  display: none;
+}
+.pwca-admin-design .pw-toggle-label {
+  position: relative;
+  display: inline-block;
+  width: 40px;
+  height: 20px;
+}
+.pwca-admin-design .pw-toggle-label .pw-toggle-slider {
+  position: absolute;
+  inset: 0;
+  border-radius: 20px;
+  background: #dcdfe5;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+  transition: background 0.2s;
+}
+.pwca-admin-design .pw-toggle-label .pw-toggle-slider::before {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  transition: transform 0.2s;
+}
+.pwca-admin-design .pw-toggle-input:checked + .pw-toggle-label .pw-toggle-slider {
+  background: #2271b1;
+}
+.pwca-admin-design .pw-toggle-input:checked + .pw-toggle-label .pw-toggle-slider::before {
+  transform: translateX(20px);
+}
+.pwca-admin-design .pw-toggle-text {
+  font-size: 12px;
+  color: #555;
+}
+.pwca-admin-design #pw-vue-filter-modal .modal__footer,
+.pwca-admin-design #pw-vue-bulk-update-modal .modal__footer {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid #eee;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }/*# sourceMappingURL=pwca-admin-design-management.css.map */

--- a/modules/admin_design/assets/scss/pwca-admin-design-management.scss
+++ b/modules/admin_design/assets/scss/pwca-admin-design-management.scss
@@ -230,5 +230,175 @@
 		align-items: center;
 		cursor: pointer;
 	}
+
+	#pw-vue-filter-modal .modal__container,
+	#pw-vue-bulk-update-modal .modal__container {
+		max-width: 360px;
+		width: 100%;
+		padding: 20px 24px;
+	}
+
+	.pw-filter-search-field {
+		display: flex;
+		align-items: center;
+		padding: 6px 10px;
+		margin-bottom: 15px;
+		border: 1px solid #ccd0d4;
+		border-radius: 4px;
+		background: #fff;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+
+		input {
+			flex: 1;
+			border: 0;
+			box-shadow: none;
+			outline: 0;
+			padding: 0;
+			font-size: 13px;
+		}
+
+		.dashicons {
+			color: #b4b9be;
+			font-size: 16px;
+		}
+
+		.dashicons-search {
+			margin-right: 6px;
+		}
+
+		.dashicons-no-alt {
+			margin-left: 6px;
+			cursor: pointer;
+		}
+	}
+
+	.pw-filter-section {
+		margin-top: 12px;
+
+		.pw-filter-toggle {
+			margin: 0 0 4px;
+			font-size: 13px;
+			font-weight: 600;
+			color: #444;
+		}
+
+		.pw-filter-options {
+			padding: 8px 0;
+			border-top: 1px solid #eee;
+		}
+	}
+
+	.pw-empty {
+		padding: 4px 0;
+		font-style: italic;
+		color: #999;
+	}
+
+	.pw-filter-item {
+		padding: 6px 0;
+		border-bottom: 1px solid #f1f1f1;
+
+		&:last-child {
+			border-bottom: 0;
+		}
+
+		.pw-filter-item-header {
+			margin-bottom: 4px;
+
+			label {
+				font-size: 13px;
+				font-weight: 500;
+				cursor: pointer;
+			}
+		}
+
+		.pw-filter-condition {
+			display: flex;
+			align-items: center;
+			gap: 6px;
+
+			select,
+			input {
+				flex: 1;
+				max-width: 100%;
+			}
+
+			select {
+				min-width: 110px;
+			}
+		}
+	}
+
+	.pw-filter-item-available {
+		padding: 4px 0;
+
+		label {
+			cursor: pointer;
+			font-size: 13px;
+		}
+	}
+
+	.pw-toggle-switch {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		margin-top: 4px;
+	}
+
+	.pw-toggle-input {
+		display: none;
+	}
+
+	.pw-toggle-label {
+		position: relative;
+		display: inline-block;
+		width: 40px;
+		height: 20px;
+
+		.pw-toggle-slider {
+			position: absolute;
+			inset: 0;
+			border-radius: 20px;
+			background: #dcdfe5;
+			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+			transition: background 0.2s;
+
+			&::before {
+				content: '';
+				position: absolute;
+				left: 2px;
+				top: 2px;
+				width: 16px;
+				height: 16px;
+				border-radius: 50%;
+				background: #fff;
+				box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+				transition: transform 0.2s;
+			}
+		}
+	}
+
+	.pw-toggle-input:checked + .pw-toggle-label .pw-toggle-slider {
+		background: #2271b1;
+	}
+
+	.pw-toggle-input:checked + .pw-toggle-label .pw-toggle-slider::before {
+		transform: translateX(20px);
+	}
+
+	.pw-toggle-text {
+		font-size: 12px;
+		color: #555;
+	}
+
+	#pw-vue-filter-modal .modal__footer,
+	#pw-vue-bulk-update-modal .modal__footer {
+		margin-top: 12px;
+		padding-top: 12px;
+		border-top: 1px solid #eee;
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+	}
 }
 


### PR DESCRIPTION
Issue: The Filter Designs modal and Bulk Update Designs modal styles disappeared in the PW Design Library admin page ( /wp-admin/admin.php?page=pw-design-library&tab=all&category&s ).

What I did:
- Reintroduced and aligned the missing CSS/SCSS for the two modals to match the intended design, with minimal code additions to ensure consistency across environments.
- Applied modal container sizing and padding to both modals for a compact 360px max width.
- Implemented the search field styling (pw-filter-search-field) with input, icons, spacing, borders, and shadows.
- Restored filter sections, toggle switches, and item rows with borders and typography to resemble the mock layout.
- Ensured the modal footers have a top border and are aligned to the right with proper spacing.
- Updated both files that govern admin design styles:
  - modules/admin_design/assets/scss/pwca-admin-design-management.css
  - modules/admin_design/assets/scss/pwca-admin-design-management.scss

These changes bring back the missing visuals with minimal code adjustments and ensure consistent styling between CSS and SCSS implementations.

---

> This pull request was co-created with Cosine Genie

Original Task: [testpw/jc3wmfh6qsib](https://cosine.sh/wordpress/testpw/task/jc3wmfh6qsib)
Author: haha haha
