### PR TITLE
fix(admin_design): 修复 PW 设计库弹窗样式（添加设计/添加分类/管理分类）

### DIFF
--- a/modules/admin_design/assets/scss/pwca-admin-design-management.scss
+++ b/modules/admin_design/assets/scss/pwca-admin-design-management.scss
@@ -402,4 +402,173 @@
 		gap: 8px;
 	}
 }
+ 
+// ---- 以下样式用于位于 .pwca-admin-design 容器之外的模态框 ----
+
+.pw-form-field {
+	margin-bottom: 16px;
+
+	label {
+		display: block;
+		margin-bottom: 4px;
+		font-weight: 600;
+		color: #333;
+	}
+
+	input[type="text"],
+	input[type="number"],
+	select,
+	textarea {
+		width: 100%;
+		max-width: 100%;
+		padding: 6px 8px;
+		border: 1px solid #ccd0d4;
+		border-radius: 4px;
+		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+		font-size: 13px;
+	}
+
+	textarea {
+		resize: vertical;
+	}
+}
+
+.pwca-upload-field {
+	.pwca-upload-label {
+		border: 2px dashed #ccc;
+		border-radius: 8px;
+		padding: 30px;
+		text-align: center;
+		background: #fafafa;
+		cursor: pointer;
+		display: block;
+		transition: all 0.2s ease;
+
+		&:hover {
+			border-color: #0073aa;
+			background: #f0f8ff;
+		}
+	}
+
+	#pw-image-preview {
+		display: none;
+	}
+
+	#pw-image-preview img {
+		max-width: 100%;
+		max-height: 200px;
+		border-radius: 4px;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+	}
+
+	input[type="file"] {
+		display: none;
+	}
+}
+
+.pw-category-item {
+	display: flex;
+	gap: 10px;
+	align-items: center;
+	padding: 12px 15px;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	margin-bottom: 10px;
+	background: #fff;
+
+	.pw-category-name-input {
+		flex: 1;
+		padding: 8px 12px;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		font-size: 14px;
+	}
+
+	.pw-category-settings-btn,
+	.pw-category-delete-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 28px;
+		height: 28px;
+		border-radius: 4px;
+		cursor: pointer;
+	}
+
+	.pw-category-settings-btn .dashicons {
+		color: #0073aa;
+	}
+
+	.pw-category-delete-btn .dashicons {
+		color: #d63638;
+	}
+}
+
+.pwca-tag-modal-body {
+	max-height: 300px;
+	overflow-y: auto;
+	border: 1px solid #ddd;
+	padding: 10px;
+	margin-bottom: 20px;
+}
+
+.pwca-checkbox-row {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+	cursor: pointer;
+}
+
+.pw-toggle-switch {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	margin-top: 4px;
+}
+
+.pw-toggle-input {
+	display: none;
+}
+
+.pw-toggle-label {
+	position: relative;
+	display: inline-block;
+	width: 40px;
+	height: 20px;
+
+	.pw-toggle-slider {
+		position: absolute;
+		inset: 0;
+		border-radius: 20px;
+		background: #dcdfe5;
+		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+		transition: background 0.2s;
+
+		&::before {
+			content: '';
+			position: absolute;
+			left: 2px;
+			top: 2px;
+			width: 16px;
+			height: 16px;
+			border-radius: 50%;
+			background: #fff;
+			box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+			transition: transform 0.2s;
+		}
+	}
+}
+
+.pw-toggle-input:checked + .pw-toggle-label .pw-toggle-slider {
+	background: #2271b1;
+}
+
+.pw-toggle-input:checked + .pw-toggle-label .pw-toggle-slider::before {
+	transform: translateX(20px);
+}
+
+.pw-toggle-text {
+	font-size: 12px;
+	color: #555;
+}
 


### PR DESCRIPTION
问题描述：后台 PW 设计库页面在点击“Add Design / Add Category / Manage Category”时弹出窗口的样式丢失，导致界面显示不一致。

解决方案：在 modules/admin_design/assets/scss/pwca-admin-design-management.scss 中增加/完善了专用于位于 .pwca-admin-design 容器之外的模态框的样式，覆盖表单字段、上传区域、分类项、模态体、复选框和开关等控件的外观，确保弹窗能够正常显示并风格统一。

变更要点：
- 新增/调整了 .pw-form-field、.pwca-upload-field、#pw-image-preview 等相关样式，涵盖输入框、文本域、上传区域等控件外观。
- 为 .pw-category-item、.pw-category-name-input、.pw-category-settings-btn、.pw-category-delete-btn 等提供统一的外观与对齐。
- 增强 .pwca-tag-modal-body、.pwca-checkbox-row、.pw-toggle-*（开关控件）等的样式，确保模态内元素滚动、对齐和交互的一致性。
- 还包括上传图片预览区域、悬停效果等细节样式，提升视觉与操作体验。

影响范围：仅修复样式，未改动页面逻辑或数据处理，向后兼容。

测试建议：
- 进入后台 PW 设计库，打开 Add Design / Add Category / Manage Category 弹出层，检查边框、间距、输入框、图片上传区、分类项的排列与按钮颜色是否符合设计预期。
- 验证弹窗在不同屏幕宽度下的布局与滚动行为是否正常。

---

> This pull request was co-created with Cosine Genie

Original Task: [testpw/tbd8v30qyz5a](https://cosine.sh/wordpress/testpw/task/tbd8v30qyz5a)
Author: haha haha
