### PR TITLE
Add admin toggle for API mock mode to switch Promowares API between real and mocked errors

### DIFF
--- a/includes/class-pw-admin-promowares-api.php
+++ b/includes/class-pw-admin-promowares-api.php
@@ -824,6 +824,17 @@ class Pw_Admin_Promowares_Api
      */
     private function call_promowares_api($endpoint, $token)
     {
+        $mock_mode = (int) get_option('pw_api_mock_mode', 0);
+        if ($mock_mode === 1) {
+            return new WP_Error(
+                'pw_mock_api_error',
+                'Mocked Promowares API error (pw_api_mock_mode is enabled).',
+                array(
+                    'endpoint' => $endpoint,
+                )
+            );
+        }
+
         $response = wp_remote_get($this->api_base_url . $endpoint, array(
             'headers' => array(
                 'Accept' => 'application/json',

--- a/modules/admin_dashboard/assets/js/pwca-admin-dashboard.js
+++ b/modules/admin_dashboard/assets/js/pwca-admin-dashboard.js
@@ -8,6 +8,8 @@
 	const clearCacheNonce = root.dataset.clearCacheNonce || ''
 	const cacheStatusNonce = root.dataset.cacheStatusNonce || ''
 	const productRequestNonce = root.dataset.productRequestNonce || ''
+	const saveMockModeNonce = root.dataset.saveMockModeNonce || ''
+	const initialApiMockMode = root.dataset.apiMockMode === '1' ? 1 : 0
 
 	const buildNotice = (type, message) => {
 		const notice = document.createElement('div')
@@ -126,6 +128,85 @@
 			} finally {
 				setBusy(false)
 			}
+		})
+	}
+
+	const initApiMockToggle = () => {
+		const container = document.getElementById('pwca-api-mock-toggle')
+		const statusContainer = document.getElementById('pwca-api-mock-status')
+
+		if (!container || !saveMockModeNonce) return
+
+		const buttons = Array.from(container.querySelectorAll('button[data-value]'))
+		if (!buttons.length) return
+
+		const setActive = (value) => {
+			buttons.forEach((button) => {
+				const buttonValue = button.dataset.value === '1' ? 1 : 0
+				if (buttonValue === value) {
+					button.classList.remove('button-secondary')
+					button.classList.add('button-primary')
+				} else {
+					button.classList.remove('button-primary')
+					button.classList.add('button-secondary')
+				}
+			})
+			container.dataset.current = String(value)
+		}
+
+		setActive(initialApiMockMode)
+
+		const setBusy = (busy) => {
+			buttons.forEach((button) => {
+				button.disabled = busy
+			})
+		}
+
+		buttons.forEach((button) => {
+			button.addEventListener('click', async (event) => {
+				event.preventDefault()
+				const value = button.dataset.value === '1' ? 1 : 0
+
+				if (String(value) === container.dataset.current) {
+					return
+				}
+
+				setBusy(true)
+				if (statusContainer) {
+					statusContainer.innerHTML = ''
+				}
+
+				try {
+					const response = await postUrlEncoded({
+						action: 'pw_save_mock_mode',
+						mode: value,
+						nonce: saveMockModeNonce,
+					})
+
+					if (response && response.success) {
+						setActive(value)
+						if (statusContainer) {
+							const message =
+								value === 1
+									? 'Mock error mode enabled. All Promowares API calls will return mocked errors.'
+									: 'Mock error mode disabled. Promowares API will return real data.'
+							setNotice(statusContainer, 'success', message)
+						}
+					} else if (statusContainer) {
+						setNotice(statusContainer, 'error', String((response && response.data) || 'Failed to save mock mode'))
+					}
+				} catch (error) {
+					if (statusContainer) {
+						setNotice(
+							statusContainer,
+							'error',
+							`Failed to save mock mode: ${error instanceof Error ? error.message : 'Unknown error'}`,
+						)
+					}
+				} finally {
+					setBusy(false)
+				}
+			})
 		})
 	}
 
@@ -398,6 +479,7 @@
 	}
 
 	initTokenConnect()
+	initApiMockToggle()
 	initImportProgress()
 	initCacheManagement()
 	initSettingsTab()

--- a/modules/admin_dashboard/includes/class-pwca-admin-dashboard.php
+++ b/modules/admin_dashboard/includes/class-pwca-admin-dashboard.php
@@ -103,13 +103,15 @@ final class Pwca_Admin_Dashboard {
 		$messages = $this->maybe_schedule_product_import();
 
 		return array(
-			'ajax_url'           => admin_url( 'admin-ajax.php' ),
-			'rest_product_base'  => trailingslashit( rest_url( 'pw/v1/product-data' ) ),
-			'save_token_nonce'   => wp_create_nonce( 'pw_save_token_nonce' ),
-			'clear_cache_nonce'  => wp_create_nonce( 'pw_clear_cache_nonce' ),
-			'cache_status_nonce' => wp_create_nonce( 'pw_cache_status_nonce' ),
-			'current_token'      => get_option( 'pw_api_token', '' ),
-			'messages'           => $messages,
+			'ajax_url'             => admin_url( 'admin-ajax.php' ),
+			'rest_product_base'    => trailingslashit( rest_url( 'pw/v1/product-data' ) ),
+			'save_token_nonce'     => wp_create_nonce( 'pw_save_token_nonce' ),
+			'clear_cache_nonce'    => wp_create_nonce( 'pw_clear_cache_nonce' ),
+			'cache_status_nonce'   => wp_create_nonce( 'pw_cache_status_nonce' ),
+			'current_token'        => get_option( 'pw_api_token', '' ),
+			'api_mock_mode'        => (int) get_option( 'pw_api_mock_mode', 0 ),
+			'save_mock_mode_nonce' => wp_create_nonce( 'pw_save_mock_mode_nonce' ),
+			'messages'             => $messages,
 		);
 	}
 

--- a/modules/admin_dashboard/views/main-page.php
+++ b/modules/admin_dashboard/views/main-page.php
@@ -4,13 +4,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$ajax_url           = isset( $view_model['ajax_url'] ) ? (string) $view_model['ajax_url'] : '';
-$rest_product_base  = isset( $view_model['rest_product_base'] ) ? (string) $view_model['rest_product_base'] : '';
-$save_token_nonce   = isset( $view_model['save_token_nonce'] ) ? (string) $view_model['save_token_nonce'] : '';
-$clear_cache_nonce  = isset( $view_model['clear_cache_nonce'] ) ? (string) $view_model['clear_cache_nonce'] : '';
-$cache_status_nonce = isset( $view_model['cache_status_nonce'] ) ? (string) $view_model['cache_status_nonce'] : '';
-$current_token      = isset( $view_model['current_token'] ) ? (string) $view_model['current_token'] : '';
-$messages           = isset( $view_model['messages'] ) && is_array( $view_model['messages'] ) ? $view_model['messages'] : array();
+$ajax_url             = isset( $view_model['ajax_url'] ) ? (string) $view_model['ajax_url'] : '';
+$rest_product_base    = isset( $view_model['rest_product_base'] ) ? (string) $view_model['rest_product_base'] : '';
+$save_token_nonce     = isset( $view_model['save_token_nonce'] ) ? (string) $view_model['save_token_nonce'] : '';
+$clear_cache_nonce    = isset( $view_model['clear_cache_nonce'] ) ? (string) $view_model['clear_cache_nonce'] : '';
+$cache_status_nonce   = isset( $view_model['cache_status_nonce'] ) ? (string) $view_model['cache_status_nonce'] : '';
+$current_token        = isset( $view_model['current_token'] ) ? (string) $view_model['current_token'] : '';
+$save_mock_mode_nonce = isset( $view_model['save_mock_mode_nonce'] ) ? (string) $view_model['save_mock_mode_nonce'] : '';
+$api_mock_mode        = isset( $view_model['api_mock_mode'] ) ? (int) $view_model['api_mock_mode'] : 0;
+$messages             = isset( $view_model['messages'] ) && is_array( $view_model['messages'] ) ? $view_model['messages'] : array();
 
 ?>
 
@@ -21,6 +23,8 @@ $messages           = isset( $view_model['messages'] ) && is_array( $view_model[
 	data-save-token-nonce="<?php echo esc_attr( $save_token_nonce ); ?>"
 	data-clear-cache-nonce="<?php echo esc_attr( $clear_cache_nonce ); ?>"
 	data-cache-status-nonce="<?php echo esc_attr( $cache_status_nonce ); ?>"
+	data-save-mock-mode-nonce="<?php echo esc_attr( $save_mock_mode_nonce ); ?>"
+	data-api-mock-mode="<?php echo esc_attr( (string) $api_mock_mode ); ?>"
 >
 	<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 
@@ -56,6 +60,19 @@ $messages           = isset( $view_model['messages'] ) && is_array( $view_model[
 			<button type="button" class="button" id="pwca-token-connect">Connect</button>
 		</div>
 		<div class="pwca-admin-dashboard__token-status" id="pwca-token-status" aria-live="polite"></div>
+	</section>
+
+	<section class="pwca-admin-dashboard__section pwca-admin-dashboard__section--api-mock">
+		<h2 class="pwca-admin-dashboard__section-title">API Mock Mode</h2>
+		<div class="pwca-admin-dashboard__row">
+			<span class="pwca-admin-dashboard__label">Promowares API</span>
+			<div class="pwca-admin-dashboard__toggle" id="pwca-api-mock-toggle" data-current="<?php echo $api_mock_mode ? '1' : '0'; ?>">
+				<button type="button" class="button <?php echo $api_mock_mode ? 'button-secondary' : 'button-primary'; ?>" data-value="0">Real Data</button>
+				<button type="button" class="button <?php echo $api_mock_mode ? 'button-primary' : 'button-secondary'; ?>" data-value="1">Mock Error</button>
+			</div>
+		</div>
+		<p class="description">Switch between real Promowares API responses and mocked error responses for testing.</p>
+		<div class="pwca-admin-dashboard__mock-status" id="pwca-api-mock-status" aria-live="polite"></div>
 	</section>
 
 	<section class="pwca-admin-dashboard__section pwca-admin-dashboard__section--currency">

--- a/modules/integration_promowares/includes/class-pwca-integration-promowares.php
+++ b/modules/integration_promowares/includes/class-pwca-integration-promowares.php
@@ -33,6 +33,7 @@ final class Pwca_Integration_Promowares {
 	public function register() {
 		add_action( 'wp_ajax_check_import_progress', array( $this, 'handle_check_import_progress' ) );
 		add_action( 'wp_ajax_pw_save_token', array( $this, 'handle_save_token' ) );
+		add_action( 'wp_ajax_pw_save_mock_mode', array( $this, 'handle_save_mock_mode' ) );
 
 		add_action( 'import_single_product', array( $this, 'import_single_product' ) );
 		add_action( 'import_composite_product_group', array( $this, 'import_composite_product_group' ) );
@@ -104,6 +105,29 @@ final class Pwca_Integration_Promowares {
 		}
 
 		wp_send_json_error( 'Token保存失败' );
+	}
+
+	public function handle_save_mock_mode() {
+		if ( ! $this->verify_ajax_nonce( 'pw_save_mock_mode_nonce', 'nonce' ) ) {
+			wp_send_json_error( '安全验证失败' );
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( '权限不足' );
+			return;
+		}
+
+		$mode_raw = isset( $_POST['mode'] ) ? sanitize_text_field( wp_unslash( $_POST['mode'] ) ) : '';
+		$mode     = (int) ( '1' === $mode_raw ? 1 : 0 );
+
+		$result = update_option( 'pw_api_mock_mode', $mode );
+		if ( $result ) {
+			wp_send_json_success( 'API 模拟模式已更新' );
+			return;
+		}
+
+		wp_send_json_error( 'API 模拟模式更新失败' );
 	}
 
 	


### PR DESCRIPTION
Summary:
- Introduces an API mock mode controlled from the admin dashboard. When enabled, Promowares API calls return mocked errors instead of real data, enabling testing and resilience checks. 

What changed:
- includes/class-pw-admin-promowares-api.php
  - call_promowares_api now respects pw_api_mock_mode. If mock mode is enabled, it returns a WP_Error instead of performing the real wp_remote_get call. The endpoint information is included in the error data for easier debugging.

- modules/integration_promowares/includes/class-pwca-integration-promowares.php
  - Register a new AJAX handler pw_save_mock_mode.
  - Added handle_save_mock_mode to persist the mock mode setting. It validates nonce, checks permissions, updates the pw_api_mock_mode option, and returns success or error messages.

- modules/admin_dashboard/includes/class-pwca-admin-dashboard.php
  - Expose api_mock_mode and save_mock_mode_nonce to the view model so the UI can render and save the toggle state.

- modules/admin_dashboard/views/main-page.php
  - Added a new API Mock Mode section with a toggle UI (Real Data vs Mock Error).
  - The section uses data attributes: data-api-mock-mode and data-save-mock-mode-nonce for initial state and secure AJAX calls.
  - Included a status area to display results of save operations.

- modules/admin_dashboard/assets/js/pwca-admin-dashboard.js
  - Implemented initApiMockToggle to render and manage the toggle, read initial state, and send an AJAX request to pw_save_mock_mode when the user changes the mode.
  - Uses the saveMockModeNonce for security and updates UI with success or error notices.

How it works:
- On page load, the UI reads the current mode from the api_mock_mode value and initializes the toggle accordingly.
- Toggling to Mock Error sends an AJAX request to save_mock_mode; on success, the UI updates to reflect the new state and shows a confirmation message. The backend persists the mode in the pw_api_mock_mode option.
- When mock mode is enabled, subsequent calls to the Promowares API (call_promowares_api) will return a mocked WP_Error, simulating an API failure. When disabled, real data is returned as before.

Usage:
- Navigate to /wp-admin/admin.php?page=pw-dashboard
- Open the API Mock Mode section and choose Real Data or Mock Error
- The setting is saved and applied immediately to API calls

This enables testing of error handling and UI behavior under API failure scenarios without changing production data.

---

> This pull request was co-created with Cosine Genie

Original Task: [testpw/b66kvir0icco](https://cosine.sh/wordpress/testpw/task/b66kvir0icco)
Author: haha haha
