### PR TITLE
Add product price sync workflow triggered by Promowares updated-at changes (REST endpoint + frontend integration)

### DIFF
--- a/includes/class-pw-admin-promowares-api.php
+++ b/includes/class-pw-admin-promowares-api.php
@@ -591,6 +591,219 @@ class Pw_Admin_Promowares_Api
             'callback' => array($this, 'handle_image_upload'),
             'permission_callback' => '__return_true',
         ));
+
+        // Register product sync status endpoint (check products/{id}/updated-at and sync price)
+        register_rest_route('pw-canvas/v1', '/product-sync-status/(?P<id>\d+)', array(
+            'methods' => 'GET',
+            'callback' => array($this, 'get_product_sync_status'),
+            'permission_callback' => '__return_true',
+            'args' => array(
+                'id' => array(
+                    'required' => true,
+                    'validate_callback' => function ($param) {
+                        return is_numeric($param) && $param > 0;
+                    },
+                    'sanitize_callback' => function ($param) {
+                        return (int) $param;
+                    },
+                ),
+            ),
+        ));
+    }
+
+    /**
+     * Get product sync status based on products/{product_id}/updated-at.
+     *
+     * - 当 Promowares 的 products/{id}/updated-at 无法获取数据时，返回错误，前端可提示用户。
+     * - 当 updated_at 发生变化时，从 Promowares 获取最新价格并与 WooCommerce 产品价格对比，
+     *   如有变化则更新 WooCommerce 价格并清理本地缓存。
+     *
+     * @since    1.0.0
+     * @param    WP_REST_Request $request The REST request object.
+     * @return   WP_REST_Response         The sync status response.
+     */
+    public function get_product_sync_status($request)
+    {
+        $product_id = isset($request['id']) ? (int) $request['id'] : 0;
+        if ($product_id <= 0) {
+            return new WP_REST_Response(array(
+                'success' => false,
+                'error' => 'Invalid product id',
+                'error_code' => 'INVALID_PRODUCT_ID',
+            ), 400);
+        }
+
+        $token = $this->hardcoded_token;
+        if (empty($token)) {
+            return new WP_REST_Response(array(
+                'success' => false,
+                'error' => 'API token not configured',
+                'error_code' => 'MISSING_TOKEN',
+            ), 401);
+        }
+
+        // 查找对应的 WooCommerce 产品
+        $woo_products = get_posts(array(
+            'post_type' => 'product',
+            'meta_query' => array(
+                array(
+                    'key' => 'pw_id',
+                    'value' => $product_id,
+                    'compare' => '=',
+                ),
+            ),
+            'posts_per_page' => 1,
+        ));
+
+        $woo_product_id = !empty($woo_products) ? (int) $woo_products[0]->ID : 0;
+        $woo_price = null;
+        $woo_regular_price = null;
+        $is_sync_product = false;
+        $woo_product = null;
+
+        if ($woo_product_id && function_exists('wc_get_product')) {
+            $woo_product = wc_get_product($woo_product_id);
+            if ($woo_product) {
+                $woo_price = (float) $woo_product->get_price();
+                $woo_regular_price = (float) $woo_product->get_regular_price();
+                $is_sync_product = get_post_meta($woo_product_id, 'pw_isSyncProduct', true) === '1';
+            }
+        }
+
+        // 请求 products/{id}/updated-at，检查远程更新时间
+        $updated_response = $this->call_promowares_api("products/{$product_id}/updated-at", $token);
+        if (is_wp_error($updated_response)) {
+            return new WP_REST_Response(array(
+                'success' => false,
+                'error' => $updated_response->get_error_message(),
+                'error_code' => $updated_response->get_error_code(),
+                'error_type' => 'REMOTE_UPDATED_AT_REQUEST_FAILED',
+                'has_woocommerce_product' => (bool) $woo_product_id,
+                'is_sync_product' => $is_sync_product,
+            ), 502);
+        }
+
+        if (!isset($updated_response['data']['updated_at'])) {
+            return new WP_REST_Response(array(
+                'success' => false,
+                'error' => 'No updated_at field in Promowares response',
+                'error_code' => 'MISSING_UPDATED_AT',
+                'error_type' => 'REMOTE_UPDATED_AT_MISSING',
+                'has_woocommerce_product' => (bool) $woo_product_id,
+                'is_sync_product' => $is_sync_product,
+            ), 500);
+        }
+
+        $remote_updated_at = (string) $updated_response['data']['updated_at'];
+        $remote_updated_ts = strtotime($remote_updated_at) ?: 0;
+
+        $last_meta_key = 'pw_remote_product_updated_at';
+        $last_updated_at = $woo_product_id ? (string) get_post_meta($woo_product_id, $last_meta_key, true) : '';
+        $last_updated_ts = $last_updated_at !== '' ? strtotime($last_updated_at) : 0;
+
+        // 如果之前没有记录，或者远程更新时间更新了，则认为 updated_at 发生变化
+        $updated_at_changed = ($last_updated_ts === 0) || ($remote_updated_ts > $last_updated_ts);
+
+        $remote_price = null;
+        $remote_anchor_price = null;
+        $price_changed = false;
+        $price_synced = false;
+        $sync_error = null;
+
+        if ($woo_product && $is_sync_product && $updated_at_changed) {
+            // 当 updated_at 有变化时，从 Promowares 获取完整产品数据以检查价格
+            $product_detail = $this->call_promowares_api("products/{$product_id}", $token);
+
+            if (is_wp_error($product_detail)) {
+                $sync_error = $product_detail->get_error_message();
+            } elseif (!isset($product_detail['data']) || !is_array($product_detail['data'])) {
+                $sync_error = 'Invalid product data from Promowares';
+            } else {
+                $data = $product_detail['data'];
+
+                if (isset($data['price']) && is_numeric($data['price'])) {
+                    $remote_price = (float) $data['price'];
+                }
+                if (isset($data['anchor_price']) && is_numeric($data['anchor_price'])) {
+                    $remote_anchor_price = (float) $data['anchor_price'];
+                }
+
+                if ($remote_price === null && $remote_anchor_price === null) {
+                    $sync_error = 'Remote product does not contain price information';
+                }
+            }
+
+            if ($sync_error === null && ($remote_price !== null || $remote_anchor_price !== null)) {
+                // 选择要写入的价格：优先使用 price 作为当前售价，anchor_price 作为原价
+                $new_price = $remote_price !== null ? $remote_price : $remote_anchor_price;
+                $new_regular_price = $remote_anchor_price !== null ? $remote_anchor_price : $remote_price;
+
+                $current_price = is_numeric($woo_price) ? (float) $woo_price : null;
+                if ($current_price !== null && $new_price !== null && (float) $new_price !== (float) $current_price) {
+                    $price_changed = true;
+                }
+
+                if ($price_changed) {
+                    // 通过 WooCommerce API 更新价格，确保缓存一致
+                    if ($new_regular_price !== null) {
+                        $woo_product->set_regular_price((string) $new_regular_price);
+                    }
+                    if ($new_price !== null) {
+                        $woo_product->set_price((string) $new_price);
+                    }
+                    $woo_product->save();
+
+                    // 同步更新底层 meta，兼容直接读取 _price/_regular_price 的逻辑
+                    if ($new_price !== null) {
+                        update_post_meta($woo_product_id, '_price', (string) $new_price);
+                    }
+                    if ($new_regular_price !== null) {
+                        update_post_meta($woo_product_id, '_regular_price', (string) $new_regular_price);
+                    }
+
+                    // WooCommerce 价格已更新，清理聚合数据缓存，确保下次前端请求拿到新价格
+                    $this->clear_cached_product_data($product_id);
+
+                    $price_synced = true;
+
+                    // 重新获取最新价格用于响应体
+                    $woo_price = (float) $woo_product->get_price();
+                    $woo_regular_price = (float) $woo_product->get_regular_price();
+                }
+            }
+        }
+
+        // 仅在价格同步未发生错误的情况下更新本地 updated_at 记录，
+        // 避免在价格同步失败时丢失后续重试机会。
+        if ($woo_product_id && $sync_error === null) {
+            update_post_meta($woo_product_id, $last_meta_key, $remote_updated_at);
+        }
+
+        $response_data = array(
+            'success' => $sync_error === null,
+            'has_woocommerce_product' => (bool) $woo_product_id,
+            'is_sync_product' => $is_sync_product,
+            'remote_updated_at' => $remote_updated_at,
+            'previous_remote_updated_at' => $last_updated_at !== '' ? $last_updated_at : null,
+            'updated_at_changed' => $updated_at_changed,
+            'woo_product_id' => $woo_product_id,
+            'woo_price' => $woo_price,
+            'woo_regular_price' => $woo_regular_price,
+            'remote_price' => $remote_price,
+            'remote_anchor_price' => $remote_anchor_price,
+            'price_changed' => $price_changed,
+            'price_synced' => $price_synced,
+        );
+
+        if ($sync_error !== null) {
+            $response_data['success'] = false;
+            $response_data['error'] = $sync_error;
+            $response_data['error_code'] = 'PRICE_SYNC_FAILED';
+
+            return new WP_REST_Response($response_data, 500);
+        }
+
+        return new WP_REST_Response($response_data, 200);
     }
 
     /**

--- a/modules/front_canvas/assets/js/canvas/page-bootstrap.js
+++ b/modules/front_canvas/assets/js/canvas/page-bootstrap.js
@@ -629,6 +629,62 @@ onReady(() => {
   // 如果是从购物车进入的编辑模式，尝试恢复对应行项目的完整画布状态
   initCartEditCanvasState();
 
+  // 基于 products/{product_id}/updated-at 检查远程数据是否更新，
+  // 如价格发生变化则由后端同步 WooCommerce 价格，并在前端刷新页面。
+  (async () => {
+    try {
+      const settings = getSettings();
+      const pwId = settings.pwId;
+      if (!pwId) {
+        return;
+      }
+
+      const restBase = (settings.restUrl || '/wp-json/').replace(/\/?$/, '/');
+      const syncUrl = `${restBase}pw-canvas/v1/product-sync-status/${encodeURIComponent(pwId)}`;
+
+      const response = await fetch(syncUrl, {
+        method: 'GET',
+        credentials: 'same-origin'
+      });
+
+      let payload;
+
+      if (!response.ok) {
+        try {
+          payload = await response.json();
+        } catch (e) {
+          payload = null;
+        }
+
+        const message = (payload && (payload.error || payload.message))
+          ? String(payload.error || payload.message)
+          : `无法检查产品最新价格（HTTP ${response.status}）`;
+
+        window.alert(message);
+        return;
+      }
+
+      payload = await response.json();
+      if (!payload || payload.success === false) {
+        const message = (payload && (payload.error || payload.message))
+          ? String(payload.error || payload.message)
+          : '无法检查产品最新价格，请稍后重试。';
+
+        window.alert(message);
+        return;
+      }
+
+      if (payload.price_changed && payload.price_synced) {
+        window.alert('该产品的价格已在后台更新，页面将刷新以显示最新价格。');
+        window.setTimeout(() => {
+          window.location.reload();
+        }, 1000);
+      }
+    } catch (e) {
+      window.alert('无法检查产品最新价格，请检查网络连接或稍后重试。');
+    }
+  })();
+
   const addToCartBtn = document.getElementById('addToCartBtn');
   if (addToCartBtn) {
     addToCartBtn.addEventListener('click', () => addCustomizedProductToCart());

--- a/modules/front_product/assets/js/product/api/productDataAPI.js
+++ b/modules/front_product/assets/js/product/api/productDataAPI.js
@@ -33,12 +33,107 @@ window.ProductDataAPI = {
             } catch (e) {
             }
 
+            // 后台 price 同步：在成功获取产品数据后，基于 products/{id}/updated-at 异步检查并同步价格
+            try {
+                if (typeof this.syncProductPriceIfNeeded === 'function') {
+                    this.syncProductPriceIfNeeded(pwId).catch(() => {
+                        // 同步失败在内部已做用户提示，这里静默处理
+                    });
+                }
+            } catch (e) {
+            }
+
             return data;
         } catch (error) {
             if (error.message && error.message.includes('HTTP error')) {
                 throw new Error(`API Error: ${error.message}`);
             } else {
                 throw new Error('网络请求失败，请检查网络连接');
+            }
+        }
+    },
+
+    /**
+     * 检查 products/{product_id}/updated-at，并在价格发生变化时同步 WooCommerce 价格。
+     *
+     * - 当 updated-at 接口不可用时，前端展示友好错误提示；
+     * - 当检测到价格已在后台同步更新时，刷新当前页面以让新价格生效。
+     *
+     * @param {string|number} pwId
+     * @returns {Promise<void>}
+     */
+    async syncProductPriceIfNeeded(pwId) {
+        const config = window.pwProductConfig;
+        if (!config || !config.restApiUrl) {
+            return;
+        }
+
+        try {
+            // 从 /pw/v1/product-data/ 派生出 /pw-canvas/v1/product-sync-status/
+            const baseUrl = config.restApiUrl.replace('/pw/v1/product-data/', '/pw-canvas/v1/product-sync-status/');
+            const syncUrl = `${baseUrl}${pwId}`;
+
+            const response = await fetch(syncUrl, {
+                method: 'GET',
+                headers: {
+                    'X-WP-Nonce': config.nonce
+                },
+                credentials: 'same-origin'
+            });
+
+            let payload;
+
+            if (!response.ok) {
+                try {
+                    payload = await response.json();
+                } catch (e) {
+                    payload = null;
+                }
+
+                const message = (payload && (payload.error || payload.message))
+                    ? String(payload.error || payload.message)
+                    : `无法检查产品最新价格（HTTP ${response.status}）`;
+
+                if (typeof window.showErrorMessage === 'function') {
+                    window.showErrorMessage(message, 7000);
+                } else {
+                    window.alert(message);
+                }
+                return;
+            }
+
+            payload = await response.json();
+            if (!payload || payload.success === false) {
+                const message = (payload && (payload.error || payload.message))
+                    ? String(payload.error || payload.message)
+                    : '无法检查产品最新价格，请稍后重试。';
+
+                if (typeof window.showErrorMessage === 'function') {
+                    window.showErrorMessage(message, 7000);
+                } else {
+                    window.alert(message);
+                }
+                return;
+            }
+
+            if (payload.price_changed && payload.price_synced) {
+                const notice = '该产品的价格已在后台更新，页面将刷新以显示最新价格。';
+                if (typeof window.showInfoMessage === 'function') {
+                    window.showInfoMessage(notice, 4000);
+                } else {
+                    window.alert(notice);
+                }
+
+                window.setTimeout(() => {
+                    window.location.reload();
+                }, 1000);
+            }
+        } catch (error) {
+            const fallbackMessage = '无法检查产品最新价格，请检查网络连接或稍后重试。';
+            if (typeof window.showErrorMessage === 'function') {
+                window.showErrorMessage(fallbackMessage, 7000);
+            } else {
+                window.alert(fallbackMessage);
             }
         }
     },


### PR DESCRIPTION
- Introduced a new REST endpoint pw-canvas/v1/product-sync-status/{id} to check Promowares products/{id}/updated-at, fetch full product data when updated-at changes, compare prices, and sync WooCommerce price if needed. It updates local price, clears caches, and returns a structured response indicating the sync result. 
- Implemented server-side logic to handle missing/invalid IDs or tokens, retrieve the corresponding WooCommerce product, compare remote and local prices, and update WooCommerce price and meta when needed. It also records the remote updated_at timestamp locally for next comparisons. 
- Frontend integration:
  - On page bootstrap (online design and product pages), added a check to call the new endpoint. If price_changed and price_synced are true, the user is alerted and the page reloads to reflect the new price.
  - In the product data flow, added syncProductPriceIfNeeded(pwId) to asynchronously trigger price synchronization after fetching product data, with user-friendly error handling.
- Testing guidance:
  - Ensure the Promowares API returns updated-at for a given product. Simulate a price change in Promowares and verify the WooCommerce product price updates and the page refreshes to show the new price.
- This addresses the requirement to alert when updated-at cannot be retrieved, detect changes, sync prices, and refresh the frontend to reflect new pricing.

---

> This pull request was co-created with Cosine Genie

Original Task: [testpw/za2hxw0rmumf](https://cosine.sh/wordpress/testpw/task/za2hxw0rmumf)
Author: haha haha
